### PR TITLE
StackBanner Styles Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/StackBanner/StackBanner.tsx
+++ b/src/StackBanner/StackBanner.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { ComponentPropsWithoutRef, FC } from "react";
 import { StackBannerListDiv } from "./stackBannerStyles";
 import StackBannerRow, { StackBannerRowProps } from "./StackBannerRow";
 
@@ -16,9 +16,9 @@ export interface StackBannerProps {
  * rows are required to display any content.
  *
  */
-const StackBanner: FC<StackBannerProps> = ({ rows = [] }) => {
+const StackBanner: FC<StackBannerProps & ComponentPropsWithoutRef<'div'>> = ({ rows = [], ...props }) => {
   return (
-    <StackBannerListDiv>
+    <StackBannerListDiv {...props}>
       {rows.map((stackBannerRowProps: StackBannerRowProps) => {
         return <StackBannerRow {...stackBannerRowProps} />;
       })}

--- a/src/StackBanner/StackBannerRow.tsx
+++ b/src/StackBanner/StackBannerRow.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MouseEvent, ReactElement } from "react";
+import React, { ComponentPropsWithoutRef, FC, MouseEvent, ReactElement } from "react";
 import { StackBannerRowDiv } from "./stackBannerStyles";
 import { StackBannerIcon, getStackBannerIcon } from "./stackBannerUtil";
 
@@ -35,11 +35,12 @@ export interface StackBannerRowProps {
  * designed to be used with a StackBanner component, but can be used as a standalone component.
  *
  */
-const StackBannerRow: FC<StackBannerRowProps> = ({
+const StackBannerRow: FC<StackBannerRowProps & ComponentPropsWithoutRef<'div'>> = ({
   content = "",
   icon = true,
   severity = "default",
   onClick = () => null,
+  ...props
 }) => {
   const svg = getStackBannerIcon(icon);
 
@@ -48,6 +49,7 @@ const StackBannerRow: FC<StackBannerRowProps> = ({
       className="stackBannerRow"
       severity={severity}
       onClick={onClick}
+      {...props}
     >
       {svg}
       <div className="content">{content}</div>

--- a/src/StackBanner/__tests__/stackBannerUtil.test.js
+++ b/src/StackBanner/__tests__/stackBannerUtil.test.js
@@ -14,7 +14,7 @@ const THEME = {
   colors: {
     white: "white",
     orange: "orange",
-    watermelon: "red",
+    red: "red",
     default: DEFAULT_BACKGROUND_COLOR,
   },
 };
@@ -24,7 +24,7 @@ describe("getSeverityColor", () => {
     expect(getSeverityColor(NORMAL_SEVERITY, THEME)).toBe(THEME.colors.white);
     expect(getSeverityColor(WARNING_SEVERITY, THEME)).toBe(THEME.colors.orange);
     expect(getSeverityColor(ERROR_SEVERITY, THEME)).toBe(
-      THEME.colors.watermelon
+      THEME.colors.red
     );
     expect(getSeverityColor(DEFAULT_SEVERITY, THEME)).toBe(
       THEME.colors.default

--- a/src/StackBanner/stackBannerUtil.tsx
+++ b/src/StackBanner/stackBannerUtil.tsx
@@ -26,7 +26,7 @@ export const getSeverityColor = (severity: string | undefined, theme?: Theme) =>
   const SEVERITY_COLORS: SeverityColors = {
     normal: theme?.colors?.white,
     warning: theme?.colors?.orange,
-    error: theme?.colors?.watermelon,
+    error: theme?.colors?.red,
     default: DEFAULT_BACKGROUND_COLOR
   };
 


### PR DESCRIPTION
This PR is for updating and extending StackBanner styles. The error banner background color has been lightened easier readability. Props are now also spread to the StackBanner and StackBannerRow components for easier customization.

![Screen Shot 2021-03-23 at 9 09 57 AM](https://user-images.githubusercontent.com/80778550/112152042-3dae2b80-8bb8-11eb-8fc5-c9e18582ab21.png)
