### PR TITLE
Fix external monitor graph centering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/StepFunctionGraph/Graph.tsx
+++ b/src/StepFunctionGraph/Graph.tsx
@@ -30,7 +30,10 @@ export interface GraphProps {
      */
     json: any;
 }
-
+const devicePixelRatio = window.devicePixelRatio;
+const DEFAULT_ZOOM = 2;
+const MIN_ZOOM = 3;
+const MAX_ZOOM = 1.2;
 const ZOOM_INCREMENT = 0.2;
 const REDRAW_THROTTLE_MS = 50;
 
@@ -68,12 +71,9 @@ export const StepFunctionGraph: FC<GraphProps> = ({ handleSelectedNode, highligh
     }), []);
 
     const canvasContainer = useRef<HTMLCanvasElement>(null);
-    const [zoom, setZoom] = useState<number>(window.devicePixelRatio);
+    const [zoom, setZoom] = useState<number>(DEFAULT_ZOOM);
     const [observedElement, setObservedElement] = useState<any>(null);
     const [clickedNode, setClickedNode] = useState<NodeDimensions | null>(null);
-    const [devicePixelRatio, setDevicePixelRatio] = useState(window.devicePixelRatio);
-    const MIN_ZOOM = useMemo(() => window.devicePixelRatio + 1, [devicePixelRatio]);
-    const MAX_ZOOM = useMemo(() => window.devicePixelRatio - 0.2, [devicePixelRatio]);
     const [jsonHighlightedNode, setJsonHighlightedNode] = useState<NodeDimensions | null>(null);
     const clickHandler = useRef<(any | null)>(null);
 
@@ -122,10 +122,10 @@ export const StepFunctionGraph: FC<GraphProps> = ({ handleSelectedNode, highligh
 
         // The pan won't reset unless there's an actual change to redraw the page
         if (zoom === devicePixelRatio) {
-            setZoom(devicePixelRatio - 0.0001);
-            setZoom(devicePixelRatio + 0.0001);
+            setZoom(DEFAULT_ZOOM - 0.0001);
+            setZoom(DEFAULT_ZOOM + 0.0001);
         } else {
-            setZoom(devicePixelRatio);
+            setZoom(DEFAULT_ZOOM);
         }
     };
 
@@ -324,12 +324,6 @@ export const StepFunctionGraph: FC<GraphProps> = ({ handleSelectedNode, highligh
     // When the page loads we need to set up the observer to see when the slider changes, which is really looking
     // at the graph itself to see if its width or properties change.
     useEffect(() => {
-        const devicePixelRatioFn = () => {
-            console.log('ratio changed.');
-            setDevicePixelRatio(window.devicePixelRatio);
-        };
-        const resolutionMatch = window.matchMedia('screen and (min-resolution: 2dppx)');
-        resolutionMatch.addEventListener('change', devicePixelRatioFn);
         const resizeCallback = (entries: any[]) => {
             setObservedElement(entries);
         };
@@ -338,7 +332,6 @@ export const StepFunctionGraph: FC<GraphProps> = ({ handleSelectedNode, highligh
         graphResizeObserver.observe(graphRef.current as HTMLDivElement);
 
         return () => {
-            resolutionMatch.removeEventListener('change', devicePixelRatioFn);
             graphResizeObserver.disconnect();
         };
     }, []);

--- a/src/StepFunctionGraph/Graph.tsx
+++ b/src/StepFunctionGraph/Graph.tsx
@@ -44,7 +44,6 @@ const REDRAW_THROTTLE_MS = 50;
  * together. It also takes a function "handleSelectedNode" that sends back which node has been clicked, so the
  * the consuming application can use the "highlightedKey" prop to let it know to highlight a node.
  * This component does not allow cycles, or nodes that connect such that a circular path is formed.
- * Note: The highlight node centering functionality may be inaccurate when using an external monitor.
  */
 export const StepFunctionGraph: FC<GraphProps> = ({ handleSelectedNode, highlightedKey, json }) => {
     const globalOffset = useMemo(() => ({


### PR DESCRIPTION
This PR fixes an issue where on different monitors, especially external monitors, the center of the graph was calculated incorrectly based on the zoom's default value.