### PR TITLE
Allow radio button content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -16,11 +16,14 @@ import {
      */
     name: string;
     /**
-     * The labels and values of the available radio buttons to select within the radio group.
+     * The options of each radio button within the radio group.
+     * Options include the `label` (appearance), `value` (returned on selection),
+     * and whether the individual option is `disabled`.
      */
     options: {
         value: string;
         label: string | ReactElement;
+        disabled?: boolean;
     }[];
     /**
      * The value of the selected radio button.
@@ -63,22 +66,23 @@ import {
         options.map((option) => {
 
           const icon = value === option.value ? <Checked /> : <Unchecked />;
+          const disableOption = disabled || option.disabled;
 
           return (
-            <StyledLabel disabled={disabled}>
-                <StyledRadioGroup
-                  {...props}
-                  name={name}
-                  options={options}
-                  value={option.value}
-                  disabled={disabled}
-                  onChange={handleChange}
-                  type="radio"
-                />
-                {icon}
-                {option.label && <div className="label">{option.label}</div>}
+            <StyledLabel disabled={disableOption}>
+              <StyledRadioGroup
+                {...props}
+                name={name}
+                options={options}
+                value={option.value}
+                disabled={disableOption}
+                onChange={disableOption ? () => null : handleChange}
+                type="radio"
+              />
+              {icon}
+              {option.label && <div className="label">{option.label}</div>}
             </StyledLabel>
-          )
+          );
         })
       }
       </ThemeProvider>

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -1,7 +1,8 @@
 import {
     ChangeEvent,
     ComponentPropsWithoutRef,
-    FC
+    FC,
+    ReactElement
   } from 'react';
   import { ThemeProvider } from '@emotion/react';
   import { StyledRadioGroup, StyledLabel } from './radioGroupStyles';
@@ -19,7 +20,7 @@ import {
      */
     options: {
         value: string;
-        label: string;
+        label: string | ReactElement;
     }[];
     /**
      * The value of the selected radio button.
@@ -75,7 +76,7 @@ import {
                   type="radio"
                 />
                 {icon}
-                {option.label && <span>{option.label}</span>}
+                {option.label && <div className="label">{option.label}</div>}
             </StyledLabel>
           )
         })

--- a/src/RadioGroup/__tests__/radioGroup.test.jsx
+++ b/src/RadioGroup/__tests__/radioGroup.test.jsx
@@ -32,5 +32,21 @@ describe('RadioGroup', () => {
             expect(radioButtons[1]).toHaveAttribute('disabled');
             expect(radioButtons[2]).toHaveAttribute('disabled');
         });
+
+        it('should disable a single button disabled when disabled is true for that option', () => {
+            const { container } = render(
+              <RadioGroup
+                name={name}
+                options={[...options, { label: 'D', value: 'D', disabled: true }]}
+              />
+            );
+
+            const radioButtons = container.querySelectorAll('input');
+
+            expect(radioButtons[0]).not.toHaveAttribute('disabled');
+            expect(radioButtons[1]).not.toHaveAttribute('disabled');
+            expect(radioButtons[2]).not.toHaveAttribute('disabled');
+            expect(radioButtons[3]).toHaveAttribute('disabled');
+        });
     });
 });

--- a/src/RadioGroup/radioGroupStyles.ts
+++ b/src/RadioGroup/radioGroupStyles.ts
@@ -14,7 +14,7 @@ export const StyledLabel = styled.label<StyledLabelProps>(
       padding: 0,
       marginBottom: 41,
       alignItems: 'center',
-      span: {
+      'div.label': {
         marginLeft: 12,
         fontSize: 16
       },

--- a/src/RadioGroup/radioGroupStyles.ts
+++ b/src/RadioGroup/radioGroupStyles.ts
@@ -21,6 +21,9 @@ export const StyledLabel = styled.label<StyledLabelProps>(
       svg: {
         color: disabled ? theme?.colors?.mercury : theme?.colors?.white,
         marginLeft: 2,
+        'path:nth-of-type(2)': {
+          fill: disabled ? theme?.colors?.mercury : undefined
+        }
       },
       cursor: disabled ? 'not-allowed' : 'auto',
   })

--- a/src/stories/RadioGroup/RadioGroup.stories.tsx
+++ b/src/stories/RadioGroup/RadioGroup.stories.tsx
@@ -92,7 +92,7 @@ MixedContentRadioGroup.args = {
                 Choose A Game
             </div>
             <div>
-            <select onChange={(e) => console.log(e)} style={{ ...contentStyle, width: '9em', marginTop: 5 }}>
+            <select style={{ ...contentStyle, width: '9em', marginTop: 5 }}>
                 <option key={'C1'} value={1}>
                     {'Chess'}
                 </option>

--- a/src/stories/RadioGroup/RadioGroup.stories.tsx
+++ b/src/stories/RadioGroup/RadioGroup.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, Story } from '@storybook/react/types-6-0';
 
 import RadioGroup, { RadioGroupProps } from 'src/RadioGroup/RadioGroup';
 import DocBlock from '.storybook/DocBlock';
+import { blue } from 'src/styles/cloudColors';
 
 export default {
     title: 'Lakefront/RadioGroup',
@@ -55,11 +56,44 @@ StandardRadioGroup.args = {
 
 export const DisabledRadioGroup = Template.bind({});
 DisabledRadioGroup.args = {
-    name: 'alphabet',
+    name: 'cells',
     options: [
-        {label: 'A', value: 'A'},
-        {label: 'B', value: 'B'},
-        {label: 'C', value: 'C'}
+        {label: 'A1', value: 'A1'},
+        {label: 'B2', value: 'B2'},
+        {label: 'C3', value: 'C3'}
     ],
     disabled: true
+};
+
+export const MixedContentRadioGroup = Template.bind({});
+const contentStyle = { height: '2em', width: '4em', borderRadius: 2 };
+MixedContentRadioGroup.args = {
+  name: 'mixedContent',
+  options: [
+    { label: 'A', value: 'A' },
+    {
+      label: <div style={{ ...contentStyle, backgroundColor: blue }} />,
+      value: 'B'
+    },
+    {
+      label: (
+        <div style={{ display: 'flex', flexDirection: 'column', width: '8em' }}>
+            <div>
+                Choose A Game
+            </div>
+            <div>
+            <select onChange={(e) => console.log(e)} style={{ ...contentStyle, width: '9em', marginTop: 5 }}>
+                <option key={'C1'} value={1}>
+                    {'Chess'}
+                </option>
+                <option key={'C2'} value={1}>
+                    {'Checkers'}
+                </option>
+            </select>
+            </div>
+        </div>
+      ),
+      value: 'C'
+    }
+  ]
 };

--- a/src/stories/RadioGroup/RadioGroup.stories.tsx
+++ b/src/stories/RadioGroup/RadioGroup.stories.tsx
@@ -54,13 +54,23 @@ StandardRadioGroup.args = {
     ]
 };
 
-export const DisabledRadioGroup = Template.bind({});
-DisabledRadioGroup.args = {
+export const SingleDisabledRadioGroupOption = Template.bind({});
+SingleDisabledRadioGroupOption.args = {
     name: 'cells',
     options: [
         {label: 'A1', value: 'A1'},
-        {label: 'B2', value: 'B2'},
+        {label: 'B2', value: 'B2', disabled: true },
         {label: 'C3', value: 'C3'}
+    ],
+};
+
+export const AllDisabledRadioGroup = Template.bind({});
+AllDisabledRadioGroup.args = {
+    name: 'states',
+    options: [
+        {label: 'AL', value: 'AL'},
+        {label: 'AK', value: 'AK'},
+        {label: 'AZ', value: 'AZ'}
     ],
     disabled: true
 };

--- a/src/stories/RadioGroup/RadioGroup.stories.tsx
+++ b/src/stories/RadioGroup/RadioGroup.stories.tsx
@@ -48,9 +48,9 @@ export const StandardRadioGroup = Template.bind({});
 StandardRadioGroup.args = {
     name: 'alphabet',
     options: [
-        {label: 'A', value: 'A'},
-        {label: 'B', value: 'B'},
-        {label: 'C', value: 'C'}
+        { label: 'A', value: 'A' },
+        { label: 'B', value: 'B' },
+        { label: 'C', value: 'C' }
     ]
 };
 
@@ -58,9 +58,9 @@ export const SingleDisabledRadioGroupOption = Template.bind({});
 SingleDisabledRadioGroupOption.args = {
     name: 'cells',
     options: [
-        {label: 'A1', value: 'A1'},
-        {label: 'B2', value: 'B2', disabled: true },
-        {label: 'C3', value: 'C3'}
+        { label: 'A1', value: 'A1' },
+        { label: 'B2', value: 'B2', disabled: true },
+        { label: 'C3', value: 'C3' }
     ],
 };
 
@@ -68,9 +68,9 @@ export const AllDisabledRadioGroup = Template.bind({});
 AllDisabledRadioGroup.args = {
     name: 'states',
     options: [
-        {label: 'AL', value: 'AL'},
-        {label: 'AK', value: 'AK'},
-        {label: 'AZ', value: 'AZ'}
+        { label: 'AL', value: 'AL' },
+        { label: 'AK', value: 'AK' },
+        { label: 'AZ', value: 'AZ' }
     ],
     disabled: true
 };


### PR DESCRIPTION
This PR addresses and should close issue #51, adding the ability to make radio group labels and valid `ReactElement` and allowing the ability to disable individual options.

![Screen Shot 2021-04-27 at 9 48 06 AM](https://user-images.githubusercontent.com/80778550/116305516-e3355b80-a771-11eb-8542-7ca92471130e.png)
![Screen Shot 2021-04-27 at 9 48 23 AM](https://user-images.githubusercontent.com/80778550/116305526-e4ff1f00-a771-11eb-877e-606fbe771014.png)
 