### PR TITLE
Enhance step function graph stories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/StepFunctionGraph/Graph.tsx
+++ b/src/StepFunctionGraph/Graph.tsx
@@ -41,7 +41,7 @@ const REDRAW_THROTTLE_MS = 50;
  * Step Function Graph Component
  *
  * The Step Function Graph takes AWS Step Function JSON and renders an interactive 2D canvas of how its states connect
- * together. It also takes a function "handleSelectedNode" that sends back which node has been clicked, so the
+ * together. It can be panned by clicking in empty space and moving the mouse. It also takes a function "handleSelectedNode" that sends back which node has been clicked, so the
  * the consuming application can use the "highlightedKey" prop to let it know to highlight a node.
  * This component does not allow cycles, or nodes that connect such that a circular path is formed.
  */

--- a/src/StepFunctionGraph/graphStyles.ts
+++ b/src/StepFunctionGraph/graphStyles.ts
@@ -7,6 +7,7 @@ export const GraphContainer = styled.div({
 });
 
 export const StyledCanvas = styled.canvas({
+    cursor: 'grab',
     height: '100%',
     width: '100%'
 });

--- a/src/stories/StepFunctionGraph/StepFunctionGraph.stories.tsx
+++ b/src/stories/StepFunctionGraph/StepFunctionGraph.stories.tsx
@@ -34,7 +34,7 @@ const Template: Story<GraphProps> = (args) => {
         args.handleSelectedNode(node);
     }
     return (
-        <div style={{height: 500, width: '100%', maxWidth: 1000}}>
+        <div style={{height: 700, width: '100%', maxWidth: 1000}}>
             <StepFunctionGraph
                 highlightedKey={highlighted}
                 json={args.json}


### PR DESCRIPTION
This PR adds a grab cursor to the step function graph when hovered over, increases the height of all storybook examples for step function graph by 200px, and adds a sentence explaining that the canvas can be panned.