### PR TITLE
Toggle component generics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -14,14 +14,15 @@
   ],
   "scripts": {
     "build": "rollup -c",
-    "build-watch": "rollup -c -w",
+    "build-storybook": "build-storybook -o docs-build",
     "build-copy": "npm run build && copyfiles -u 1 \"dist/**/*\" $npm_config_target",
+    "build-watch": "rollup -c -w",
     "lint": "eslint --ext .jsx,.js,.ts,.tsx src",
     "lint:fix": "eslint --ext .jsx,.js,.ts,.tsx src --fix",
-    "test": "jest",
-    "test-watch": "jest --watch",
+    "start": "npm run storybook",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook -o docs-build"
+    "test": "jest",
+    "test-watch": "jest --watch"
   },
   "dependencies": {
     "@emotion/react": "^11.1.5",

--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -4,7 +4,7 @@ import theme from '../styles/theme';
 import { ThemeProvider } from '@emotion/react';
 
 export interface ToggleOption<T> {
-    name: string;
+    label: string;
     value: T;
 }
 
@@ -54,7 +54,7 @@ const Toggle = <T, >({
     const [firstOption, secondOption] = options;
     const isFirstOption = value === firstOption.value;
     const iconPosition = isFirstOption ? 0 : 16;
-    const label = isFirstOption ? firstOption.name : secondOption.name;
+    const label = isFirstOption ? firstOption.label : secondOption.label;
     const labelOrder = position === 'LEFT' ? 0 : 2;
 
     const handleToggleClick = () => {
@@ -72,7 +72,7 @@ const Toggle = <T, >({
         <ThemeProvider theme={theme}>
             <ToggleWrapper className={className}>
                 <Label disabled={disabled} style={{ order: labelOrder }} onClick={handleToggleClick}>{label}</Label>
-                <IconWrapper disabled={disabled} onClick={handleToggleClick}>
+                <IconWrapper disabled={disabled} position={position} onClick={handleToggleClick}>
                     <Bar disabled={disabled} options={options} value={value} />
                     <Icon disabled={disabled} style={{ left: iconPosition }} />
                 </IconWrapper>

--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -3,12 +3,12 @@ import { Bar, Icon, IconWrapper, Label, ToggleWrapper } from './toggleStyles';
 import theme from '../styles/theme';
 import { ThemeProvider } from '@emotion/react';
 
-export interface ToggleOption {
+export interface ToggleOption<T> {
     name: string;
-    value: string;
+    value: T;
 }
 
-export interface ToggleProps {
+export interface ToggleProps<T> {
     /**
      * Optional className for styling component.
      */
@@ -20,12 +20,12 @@ export interface ToggleProps {
     /**
      * Options for the labels and their values. It should only contain two objects.
      */
-    options: ToggleOption[];
+    options: ToggleOption<T>[];
     /**
      * This is called whenever the switch toggles with the value of the option.
      * Clicking the label also toggles the switch.
      */
-    onChange: (value: string) => void;
+    onChange: (value: T) => void;
     /**
      * Determines which side of the switch the label is rendered.
      */
@@ -33,7 +33,7 @@ export interface ToggleProps {
     /**
      * The currently selected value. This value is passed in from the parent component.
      */
-    value: string;
+    value: T;
 }
 
 /**
@@ -43,14 +43,14 @@ export interface ToggleProps {
  * It has a position prop to change the layout of the label. State for the value needs to be maintained in a parent
  * component and passed in as a prop.
  */
-const Toggle: FC<ToggleProps> = ({
+const Toggle = <T, >({
         className,
         disabled,
         options,
         onChange,
         position = 'RIGHT',
         value
-    }) => {
+    }: ToggleProps<T>) => {
     const [firstOption, secondOption] = options;
     const isFirstOption = value === firstOption.value;
     const iconPosition = isFirstOption ? 0 : 16;

--- a/src/Toggle/__tests__/toggle.test.jsx
+++ b/src/Toggle/__tests__/toggle.test.jsx
@@ -4,11 +4,11 @@ import Toggle from '../Toggle';
 
 const toggleOptions = [
     {
-        name: 'First',
+        label: 'First',
         value: 'first'
     },
     {
-        name: 'Second',
+        label: 'Second',
         value: 'second'
     }
 ];
@@ -31,7 +31,7 @@ describe('Toggle', () => {
 
         const [icon] = container.querySelectorAll('div span:nth-of-type(2)');
 
-        expect(getByText(toggleOptions[0].name)).toBeInTheDocument();
+        expect(getByText(toggleOptions[0].label)).toBeInTheDocument();
         expect(icon).toHaveStyle('left: 0px');
     });
 
@@ -46,7 +46,7 @@ describe('Toggle', () => {
 
         const [icon] = container.querySelectorAll('div span:nth-of-type(2)');
 
-        expect(getByText(toggleOptions[1].name)).toBeInTheDocument();
+        expect(getByText(toggleOptions[1].label)).toBeInTheDocument();
         expect(icon).toHaveStyle('left: 16px');
     });
 
@@ -59,9 +59,9 @@ describe('Toggle', () => {
             />
         );
 
-        expect(getByText(toggleOptions[0].name)).toBeInTheDocument();
+        expect(getByText(toggleOptions[0].label)).toBeInTheDocument();
 
-        const label = getByText(toggleOptions[0].name);
+        const label = getByText(toggleOptions[0].label);
         const [wrapper] = container.querySelectorAll('div');
 
         fireEvent.click(label);
@@ -84,9 +84,9 @@ describe('Toggle', () => {
             />
         );
 
-        expect(getByText(toggleOptions[0].name)).toBeInTheDocument();
+        expect(getByText(toggleOptions[0].label)).toBeInTheDocument();
 
-        const label = getByText(toggleOptions[0].name);
+        const label = getByText(toggleOptions[0].label);
         const [wrapper] = container.querySelectorAll('div');
 
         fireEvent.click(label);

--- a/src/Toggle/toggleStyles.ts
+++ b/src/Toggle/toggleStyles.ts
@@ -2,13 +2,13 @@ import styled from '@emotion/styled';
 import { ToggleProps } from './Toggle';
 import { hexToRgb } from '../styles/stylesUtil';
 
-export const Label = styled.span<Pick<ToggleProps, 'disabled'>>(({ theme, disabled }) => ({
+export const Label = styled.span<Pick<ToggleProps<unknown>, 'disabled'>>(({ theme, disabled }) => ({
     color: disabled ? theme?.colors?.doveGrey : theme?.colors?.black,
     cursor: 'pointer',
     fontSize: 16
 }));
 
-export const Bar = styled.span<Pick<ToggleProps, 'options' | 'value' | 'disabled'>>(({ theme, disabled, options, value }) => {
+export const Bar = styled.span<Pick<ToggleProps<unknown>, 'options' | 'value' | 'disabled'>>(({ theme, disabled, options, value }) => {
     const backgroundColor = value === options[0].value ? theme?.colors?.alto : theme?.colors?.calmingBlue;
 
     return {
@@ -20,7 +20,7 @@ export const Bar = styled.span<Pick<ToggleProps, 'options' | 'value' | 'disabled
     };
 });
 
-export const Icon = styled.span<Pick<ToggleProps, 'disabled'>>(({ theme, disabled }) => ({
+export const Icon = styled.span<Pick<ToggleProps<any>, 'disabled'>>(({ theme, disabled }) => ({
     backgroundColor: disabled ? theme?.colors?.bombay : theme?.colors?.storm,
     borderRadius: 20,
     height: 20,
@@ -30,9 +30,9 @@ export const Icon = styled.span<Pick<ToggleProps, 'disabled'>>(({ theme, disable
     transition: 'left 0.2s'
 }));
 
-export const IconWrapper = styled.div<Pick<ToggleProps, 'disabled'>>(({ theme, disabled }) => ({
+export const IconWrapper = styled.div<Pick<ToggleProps<any>, 'disabled' | 'position'>>(({ theme, disabled, position }) => ({
     position: 'relative',
-    margin: '0 12px',
+    ...(position === 'LEFT' ? { marginLeft: 12 } : { marginRight: 12 }),
     padding: '12px 0',
     cursor: 'pointer',
     ':hover span:nth-of-type(2)': {

--- a/src/Toggle/toggleStyles.ts
+++ b/src/Toggle/toggleStyles.ts
@@ -20,7 +20,7 @@ export const Bar = styled.span<Pick<ToggleProps<unknown>, 'options' | 'value' | 
     };
 });
 
-export const Icon = styled.span<Pick<ToggleProps<any>, 'disabled'>>(({ theme, disabled }) => ({
+export const Icon = styled.span<Pick<ToggleProps<unknown>, 'disabled'>>(({ theme, disabled }) => ({
     backgroundColor: disabled ? theme?.colors?.bombay : theme?.colors?.storm,
     borderRadius: 20,
     height: 20,
@@ -30,7 +30,7 @@ export const Icon = styled.span<Pick<ToggleProps<any>, 'disabled'>>(({ theme, di
     transition: 'left 0.2s'
 }));
 
-export const IconWrapper = styled.div<Pick<ToggleProps<any>, 'disabled' | 'position'>>(({ theme, disabled, position }) => ({
+export const IconWrapper = styled.div<Pick<ToggleProps<unknown>, 'disabled' | 'position'>>(({ theme, disabled, position }) => ({
     position: 'relative',
     ...(position === 'LEFT' ? { marginLeft: 12 } : { marginRight: 12 }),
     padding: '12px 0',

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,6 @@ export { default as StackBanner } from './StackBanner/StackBanner';
 export { default as StackBannerRow } from './StackBanner/StackBannerRow';
 export { default as SelectPopover } from './SelectPopover/SelectPopover';
 export { default as StepFunctionGraph } from'./StepFunctionGraph/Graph';
-export { default as Toggle } from './Toggle/Toggle';
+export { default as Toggle, ToggleOption } from './Toggle/Toggle';
 export { default as colors } from './styles/cloudColors';
 export { default as theme } from './styles/theme';

--- a/src/stories/Toggle/Toggle.stories.tsx
+++ b/src/stories/Toggle/Toggle.stories.tsx
@@ -22,7 +22,7 @@ export default {
     }
 } as Meta;
 
-const toggleOptions: ToggleOption[] = [
+const toggleOptions: ToggleOption<string>[] = [
     {
         name: 'First',
         value: 'first'
@@ -33,7 +33,9 @@ const toggleOptions: ToggleOption[] = [
     }
 ];
 
-const Template: Story<ToggleProps> = (args) => {
+
+
+const Template: Story<ToggleProps<string>> = (args) => {
     const [selected, setSelected] = useState(toggleOptions[0].value);
     const handleChange = (value: string) => {
         setSelected(value);

--- a/src/stories/Toggle/Toggle.stories.tsx
+++ b/src/stories/Toggle/Toggle.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, useState } from 'react';
+import { useState } from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 
 import DocBlock from '.storybook/DocBlock';
@@ -24,11 +24,11 @@ export default {
 
 const toggleOptions: ToggleOption<string>[] = [
     {
-        name: 'First',
+        label: 'First',
         value: 'first'
     },
     {
-        name: 'Second',
+        label: 'Second',
         value: 'second'
     }
 ];


### PR DESCRIPTION
This PR replaces the `string` type in the toggle component options with a generic type to allow for more flexible and robust usage. The toggle options `name` field was also renamed to `label`. `npm start` was added to the package.json scripts to run the storybook command. The toggle margin was made dynamic based on the position of the label.