### PR TITLE
Add ref forwarding to TextArea

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, FC } from 'react';
+import { ComponentPropsWithRef, FC, forwardRef } from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { StyledTextArea, StyledLabel } from './textAreaStyles';
 import theme from '../styles/theme';
@@ -22,16 +22,16 @@ export interface TextAreaProps {
  * in this component and should be handled in the consuming app.
  *
  */
-const TextArea: FC<TextAreaProps & ComponentPropsWithoutRef<'textarea'>> = ({ label, error = '', ...props }) => {
+const TextArea: FC<TextAreaProps & ComponentPropsWithRef<'textarea'>> = forwardRef(({ label, error = '', ...props }, ref) => {
     return (
         <ThemeProvider theme={theme}>
             <StyledLabel error={error}>
                 {label && <span>{label}</span>}
-                <StyledTextArea error={error} {...props} />
+                <StyledTextArea ref={ref} error={error} {...props} />
                 <div>{error}</div>
             </StyledLabel>
         </ThemeProvider>
     );
-};
+});
 
 export default TextArea;


### PR DESCRIPTION
This PR allows the user to add a ref  prop to the TextArea component and closes #75 if approved.