### PR TITLE
Fix stories folder tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/stories/tsconfig.json
+++ b/src/stories/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+        "baseUrl": "../../",
+        "jsx": "react-jsx"
+    },
+    "include": ["./**/*"]
+}


### PR DESCRIPTION
Added a tsconfig in the stories folder so the files within can resolve modules correctly while staying out of the rollup build that uses the main tsconfig in the root directory.