### PR TITLE
Absolute import fix

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -82,7 +82,8 @@ export default {
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   moduleNameMapper: {
-    '\\.svg': '<rootDir>/config/svgrMock.js'
+    '\\.svg': '<rootDir>/config/svgrMock.js',
+    'src/(.*)': '<rootDir>/src/$1'
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.43.5",
+  "version": "0.43.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.43.5",
+  "version": "0.43.6",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -9,7 +9,7 @@ import {
     InvalidButtonColorError,
     shouldUseMappedIcon
 } from './buttonUtil';
-import theme from '../styles/theme';
+import theme from 'src/styles/theme';
 
 /**
  * Button Component

--- a/src/Button/IconButton.tsx
+++ b/src/Button/IconButton.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { IconComponentProps } from './buttonUtil';
 import styled from '@emotion/styled';
-import theme from '../styles/theme';
+import theme from 'src/styles/theme';
 
 interface IconSpanProps {
     iconPosition?: 'left' | 'right';

--- a/src/Button/__tests__/button.test.jsx
+++ b/src/Button/__tests__/button.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import Button from '../Button';
-import { lightenDarkenColor } from '../../styles/stylesUtil';
+import { lightenDarkenColor } from 'src/styles/stylesUtil';
 
 const BUTTON_TEXT = 'buttonText';
 

--- a/src/Button/buttonVariants.ts
+++ b/src/Button/buttonVariants.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { lightenDarkenColor } from '../styles/stylesUtil';
+import { lightenDarkenColor } from 'src/styles/stylesUtil';
 import { ButtonComponentProps, ComponentStyles } from './buttonUtil';
 import { css, Theme } from '@emotion/react';
 import { getIconStyles } from './iconButtonVariants';

--- a/src/Button/iconButtonVariants.ts
+++ b/src/Button/iconButtonVariants.ts
@@ -1,5 +1,5 @@
 import { css, Theme } from '@emotion/react';
-import { lightenDarkenColor } from '../styles/stylesUtil';
+import { lightenDarkenColor } from 'src/styles/stylesUtil';
 import { ComponentStyles } from './buttonUtil';
 
 const MAIN_STYLES = {

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -8,7 +8,7 @@ import { ThemeProvider } from '@emotion/react';
 import { StyledCheckbox, StyledLabel } from './checkboxStyles';
 import { ReactComponent as Check } from './assets/check.svg';
 import { ReactComponent as Indeterminate } from './assets/indeterminate.svg';
-import theme from '../styles/theme';
+import theme from 'src/styles/theme';
 
 export interface CheckboxProps {
   /**

--- a/src/Collapsible/Collapsible.tsx
+++ b/src/Collapsible/Collapsible.tsx
@@ -6,10 +6,10 @@ import {
 } from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { StyledCollapsible } from './collapsibleStyles';
-import Button from '../Button/Button';
+import Button from 'src/Button/Button';
 import { ReactComponent as ChevronUp } from './assets/chevron-up.svg';
 import { ReactComponent as ChevronDown } from './assets/chevron-down.svg';
-import theme from '../styles/theme';
+import theme from 'src/styles/theme';
 
 export interface CollapsibleProps {
   /**

--- a/src/Filter/Filter.tsx
+++ b/src/Filter/Filter.tsx
@@ -14,7 +14,7 @@ import {
 import { ReactComponent as Add } from './assets/add.svg';
 import { ReactComponent as Remove } from './assets/remove.svg';
 import { ReactComponent as FilterIcon } from './assets/filterIcon.svg';
-import theme from '../styles/theme';
+import theme from 'src/styles/theme';
 
 /**
  * Filter Component

--- a/src/Filter/modules/RadioFilter/RadioFilter.tsx
+++ b/src/Filter/modules/RadioFilter/RadioFilter.tsx
@@ -1,4 +1,4 @@
-import RadioGroup from '../../../RadioGroup/RadioGroup';
+import RadioGroup from 'src/RadioGroup/RadioGroup';
 import { FilterModule, RadioFilterProps, RadioFilterOptions } from 'src/Filter/types';
 import { RadioGroupContainer } from './radioFilterStyles';
 

--- a/src/Filter/modules/TextFilter/textSearchStyles.ts
+++ b/src/Filter/modules/TextFilter/textSearchStyles.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import Input from '../../../Input/Input';
+import Input from 'src/Input/Input';
 
 export const StyledInput = styled(Input)({
     width: '100%'

--- a/src/Filter/util/__tests__/filterHooks.test.jsx
+++ b/src/Filter/util/__tests__/filterHooks.test.jsx
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useFilter } from '../filterHooks';
 import queryString from 'query-string';
-import { DEFAULT_PHRASE_DEMO, FILTERS, KEYWORD_DEMO, LOCATION, PHRASE_DEMO } from '../../__tests__/filter.data';
+import { DEFAULT_PHRASE_DEMO, FILTERS, KEYWORD_DEMO, LOCATION, PHRASE_DEMO } from 'src/Filter/__tests__/filter.data';
 
 describe('useFilter', () => {
     it('should have initial values', () => {

--- a/src/Filter/util/__tests__/filterHooksUtil.test.js
+++ b/src/Filter/util/__tests__/filterHooksUtil.test.js
@@ -5,7 +5,7 @@ import {
     getCurrentBrowserQueryParams,
     getFilterBrowserQueryParams
 } from '../filterHooksUtil';
-import { FILTERS, KEYWORD_DEMO, PHRASE_DEMO } from '../../__tests__/filter.data';
+import { FILTERS, KEYWORD_DEMO, PHRASE_DEMO } from 'src/Filter/__tests__/filter.data';
 
 const FILTER_HOOKS_UTIL_VALUES = { keywords: KEYWORD_DEMO, phrases: PHRASE_DEMO };
 const FILTER_HOOKS_UTIL_LOCATION = { search: `&keywords=${KEYWORD_DEMO}&phrases=${encodeURIComponent(PHRASE_DEMO)}` };

--- a/src/Filter/util/__tests__/filterUtil.test.js
+++ b/src/Filter/util/__tests__/filterUtil.test.js
@@ -1,5 +1,5 @@
 import { getDefaultValue, getDefaultJsonViewValue, getFilterAppliedCount } from '../filterUtil';
-import { FILTERS } from '../../__tests__/filter.data';
+import { FILTERS } from 'src/Filter/__tests__/filter.data';
 
 describe('getDefaultValue', () => {
     describe('when url parameter key exists', () => {

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -1,7 +1,7 @@
 import { ComponentPropsWithoutRef, FC } from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { StyledInput, StyledLabel } from './inputStyles';
-import theme from '../styles/theme';
+import theme from 'src/styles/theme';
 
 export interface InputProps {
     /**

--- a/src/Input/__tests__/input.test.jsx
+++ b/src/Input/__tests__/input.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import Input from '../../Input/Input';
+import Input from '../Input';
 
 const LABEL = 'Label';
 const ERROR = 'Error';

--- a/src/Loading/Loading.tsx
+++ b/src/Loading/Loading.tsx
@@ -2,7 +2,7 @@ import { ElementType, FC, ReactElement } from 'react';
 import { ReactComponent as SpinnerLogo } from './assets/tri_logo_monochrome.svg';
 import { StyledLoadingContainer } from './loadingStyles';
 import { ThemeProvider } from '@emotion/react';
-import theme from '../styles/theme';
+import theme from 'src/styles/theme';
 export interface LoadingProps {
     /**
      * Determines if the component should rotate.

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -8,7 +8,7 @@ import {
   import { StyledRadioGroup, StyledLabel } from './radioGroupStyles';
   import { ReactComponent as Checked } from './assets/radioChecked.svg';
   import { ReactComponent as Unchecked } from './assets/radioUnchecked.svg';
-  import theme from '../styles/theme';
+  import theme from 'src/styles/theme';
 
   export interface RadioGroupProps {
     /**

--- a/src/RadioGroup/__tests__/radioGroup.test.jsx
+++ b/src/RadioGroup/__tests__/radioGroup.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import RadioGroup from '../../RadioGroup/RadioGroup';
+import RadioGroup from '../RadioGroup';
 
 const name = 'Alphabet';
 const options = [

--- a/src/SelectPopover/SelectPopover.tsx
+++ b/src/SelectPopover/SelectPopover.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactElement, useEffect, useMemo, useState } from 'react';
 import { SelectPopoverItem, StyledSelectPopover, StyledSelectPopoverWrapper } from './selectPopoverStyles';
 import { createPortal } from 'react-dom';
-import theme from '../styles/theme';
+import theme from 'src/styles/theme';
 import { ThemeProvider } from '@emotion/react';
 
 export interface SelectPopoverOption {

--- a/src/SelectPopover/__tests__/selectPopover.test.jsx
+++ b/src/SelectPopover/__tests__/selectPopover.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import SelectPopover from '../../SelectPopover/SelectPopover';
-import Button from '../../Button/Button';
+import SelectPopover from '../SelectPopover';
+import Button from 'src/Button/Button';
 
 const options = [
     {

--- a/src/SelectPopover/selectPopoverStyles.ts
+++ b/src/SelectPopover/selectPopoverStyles.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { lightenDarkenColor } from '../styles/stylesUtil';
+import { lightenDarkenColor } from 'src/styles/stylesUtil';
 
 const DARKEN_MOST = -40;
 

--- a/src/StackBanner/StackBanner.tsx
+++ b/src/StackBanner/StackBanner.tsx
@@ -2,7 +2,7 @@ import { ComponentPropsWithoutRef, FC } from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { StackBannerListDiv } from './stackBannerStyles';
 import StackBannerRow, { StackBannerRowProps } from './StackBannerRow';
-import theme from '../styles/theme';
+import theme from 'src/styles/theme';
 
 export interface StackBannerProps {
   /**

--- a/src/StepFunctionGraph/Graph.tsx
+++ b/src/StepFunctionGraph/Graph.tsx
@@ -7,12 +7,12 @@ import { ReactComponent as RemoveIcon } from './assets/minus.svg';
 import Digraph from './Digraph';
 import DigraphDFS from './DigraphDFS';
 import { drawGraph } from './GraphRenderer';
-import resizeObserver from '../lib/hooks/resizeObserver.js';
-import throttled from '../lib/hooks/throttle.js';
+import resizeObserver from 'src/lib/hooks/resizeObserver.js';
+import throttled from 'src/lib/hooks/throttle.js';
 import { NodeDimensions } from './GraphUtil';
 import { collides } from './canvasUtil';
 import { GraphControls, GraphContainer, StyledCanvas } from './graphStyles';
-import theme from '../styles/theme';
+import theme from 'src/styles/theme';
 import { ThemeProvider } from '@emotion/react';
 
 export interface GraphProps {

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -1,7 +1,7 @@
 import { ComponentPropsWithRef, FC, forwardRef } from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { StyledTextArea, StyledLabel } from './textAreaStyles';
-import theme from '../styles/theme';
+import theme from 'src/styles/theme';
 
 export interface TextAreaProps {
     /**

--- a/src/TextArea/__tests__/textArea.test.jsx
+++ b/src/TextArea/__tests__/textArea.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import TextArea from '../../TextArea/TextArea';
+import TextArea from '../TextArea';
 
 const LABEL = 'Label';
 const ERROR = 'Error';

--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -1,5 +1,5 @@
 import { Bar, Icon, IconWrapper, Label, ToggleWrapper } from './toggleStyles';
-import theme from '../styles/theme';
+import theme from 'src/styles/theme';
 import { ThemeProvider } from '@emotion/react';
 
 export interface ToggleOption<T> {

--- a/src/Toggle/toggleStyles.ts
+++ b/src/Toggle/toggleStyles.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { ToggleProps } from './Toggle';
-import { hexToRgb } from '../styles/stylesUtil';
+import { hexToRgb } from 'src/styles/stylesUtil';
 
 export const Label = styled.span<Pick<ToggleProps<unknown>, 'disabled'>>(({ theme, disabled }) => ({
     color: disabled ? theme?.colors?.doveGrey : theme?.colors?.black,

--- a/src/stories/SelectPopover/SelectPopover.stories.tsx
+++ b/src/stories/SelectPopover/SelectPopover.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, Story } from '@storybook/react/types-6-0';
 
 import SelectPopover, { SelectPopoverProps } from 'src/SelectPopover/SelectPopover';
 import DocBlock from '.storybook/DocBlock';
-import { Button } from '../../index';
+import Button from 'src/Button/Button';
 import { blue } from 'src/styles/cloudColors';
 
 export default {

--- a/src/stories/StepFunctionGraph/StepFunctionGraph.stories.tsx
+++ b/src/stories/StepFunctionGraph/StepFunctionGraph.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 
 import DocBlock from '.storybook/DocBlock';
-import StepFunctionGraph, { GraphProps } from '../../StepFunctionGraph/Graph';
+import StepFunctionGraph, { GraphProps } from 'src/StepFunctionGraph/Graph';
 import { choiceJson, mapInMap, longJson, simpleJson, complexJson } from './stepFunctionGraphData';
 import { useState } from 'react';
 


### PR DESCRIPTION
This PR fixes an issue where jest would fail when absolute imports would fail to be recognized. I also used this PR as an opportunity to change deeply nested or unrelated relative imports to absolute imports. If approved, this would close #96 .