### PR TITLE
Add ref forwarding to Input component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.44.6",
+  "version": "0.45.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.44.6",
+  "version": "0.45.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, FC } from 'react';
+import { ComponentPropsWithoutRef, forwardRef } from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { StyledInput, StyledLabel } from './inputStyles';
 import theme from 'src/styles/theme';
@@ -22,8 +22,8 @@ export interface InputProps {
  * in this component and should be handled in the consuming app.
  *
  */
-const Input: FC<InputProps & ComponentPropsWithoutRef<'input'>> = ({ label, error = '', ...props }) => {
-    return (
+const Input = forwardRef<HTMLInputElement, InputProps & ComponentPropsWithoutRef<'input'>>(
+    ({ label, error = '', ...props }, ref) => (
         <ThemeProvider theme={theme}>
             <StyledLabel error={error}>
                 {label && <span>{label}</span>}
@@ -31,7 +31,7 @@ const Input: FC<InputProps & ComponentPropsWithoutRef<'input'>> = ({ label, erro
                 <div>{error}</div>
             </StyledLabel>
         </ThemeProvider>
-    );
-};
+    )
+);
 
 export default Input;

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, forwardRef } from 'react';
+import { FC, forwardRef, ComponentPropsWithRef } from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { StyledInput, StyledLabel } from './inputStyles';
 import theme from 'src/styles/theme';
@@ -22,12 +22,11 @@ export interface InputProps {
  * in this component and should be handled in the consuming app.
  *
  */
-const Input = forwardRef<HTMLInputElement, InputProps & ComponentPropsWithoutRef<'input'>>(
-    ({ label, error = '', ...props }, ref) => (
+const Input: FC<InputProps & ComponentPropsWithRef<'input'>> = forwardRef(({ label, error = '', ...props }, ref) => (
         <ThemeProvider theme={theme}>
             <StyledLabel error={error}>
                 {label && <span>{label}</span>}
-                <StyledInput error={error} {...props} />
+                <StyledInput ref={ref} error={error} {...props} />
                 <div>{error}</div>
             </StyledLabel>
         </ThemeProvider>


### PR DESCRIPTION
This PR adds ref forwarding to the Input component. The purpose of this is for the current Input component to plug and play nicely with react-hook-form (https://react-hook-form.com/get-started).