### PR TITLE
SelectOption aliased as ToggleOption build errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.52.6",
+  "version": "0.52.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.52.6",
+  "version": "0.52.7",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -1,9 +1,7 @@
 import { Bar, Icon, IconWrapper, Label, ToggleWrapper } from './toggleStyles';
 import theme from 'src/styles/theme';
 import { ThemeProvider } from '@emotion/react';
-import { SelectOption as ToggleOption } from 'src/types/global';
-
-export { ToggleOption };
+import { SelectOption } from 'src/types/global';
 
 export interface ToggleProps<T> {
     /**
@@ -17,7 +15,7 @@ export interface ToggleProps<T> {
     /**
      * Options for the labels and their values. It should only contain two objects.
      */
-    options: ToggleOption<T>[];
+    options: SelectOption<T>[];
     /**
      * This is called whenever the switch toggles with the value of the option.
      * Clicking the label also toggles the switch.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+// Components
 export { default as Button } from './Button/Button';
 
 export { default as Checkbox } from './Checkbox/Checkbox';
@@ -27,9 +28,12 @@ export { default as StepFunctionGraph } from'./StepFunctionGraph/Graph';
 
 export { default as TextArea } from'./TextArea/TextArea';
 
-export { default as Toggle, ToggleOption } from './Toggle/Toggle';
+export { default as Toggle } from './Toggle/Toggle';
 
+// Theme
 export { default as colors } from './styles/cloudColors';
 
 export { default as theme } from './styles/theme';
 
+// Types
+export { SelectOption } from './types/global';

--- a/src/stories/Toggle/Toggle.stories.tsx
+++ b/src/stories/Toggle/Toggle.stories.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 
 import DocBlock from '.storybook/DocBlock';
-import ToggleComponent, { ToggleOption, ToggleProps } from 'src/Toggle/Toggle';
+import ToggleComponent, { ToggleProps } from 'src/Toggle/Toggle';
+import { SelectOption } from 'src/types/global';
 
 export default {
     title: 'Lakefront/Toggle',
@@ -22,7 +23,7 @@ export default {
     }
 } as Meta;
 
-const toggleOptions: ToggleOption<string>[] = [
+const toggleOptions: SelectOption<string>[] = [
     {
         label: 'First',
         value: 'first'


### PR DESCRIPTION
This PR addresses an issue that occurred due to SelectOption being imported and exported aliased as ToggleOption. If approved, this will close #123 .