### PR TITLE
Single select typing error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.52.8",
+  "version": "0.52.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.52.6",
+  "version": "0.52.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.52.7",
+  "version": "0.52.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.52.7",
+  "version": "0.52.8",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.52.8",
+  "version": "0.52.9",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.52.6",
+  "version": "0.52.7",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/Filter/modules/AdditionalJSONFilter/AdditionalJSONFilter.tsx
+++ b/src/Filter/modules/AdditionalJSONFilter/AdditionalJSONFilter.tsx
@@ -19,7 +19,7 @@ const AdditionalJSONFilter = (additionalJSONFilterOptions: AdditionalJSONFilterO
     inputHidden: true,
     getApiQueryUrl: () => '',
     getApiPostBody: (_, value) => value,
-    getBrowserQueryUrlValue: value => (isActualValue(value) ? JSON.stringify(value) : undefined),
+    getBrowserQueryUrlValue: value => isActualValue(value) ? JSON.stringify(value) : '',
     getDefaultFilterValue: () => undefined,
     isDefaultFilterValue: value => !isActualValue(value),
     getFilterBarLabel: value => (value ? ADDITIONAL_JSON_FILTER_BAR_LABEL : ''),

--- a/src/Filter/modules/AdditionalJSONFilter/__tests__/additionalJSONFilter.test.js
+++ b/src/Filter/modules/AdditionalJSONFilter/__tests__/additionalJSONFilter.test.js
@@ -41,10 +41,10 @@ describe('AdditionalJSONFilter', () => {
             expect(getBrowserQueryUrlValue([1])).toBe(JSON.stringify([1]));
         });
 
-        it('returns undefined if value is not an actual value', () => {
-            expect(getBrowserQueryUrlValue()).toBeUndefined();
-            expect(getBrowserQueryUrlValue(1)).toBeUndefined();
-            expect(getBrowserQueryUrlValue([])).toBeUndefined();
+        it('returns empty string if value is not an actual value', () => {
+            expect(getBrowserQueryUrlValue()).toBe('');
+            expect(getBrowserQueryUrlValue(1)).toBe('');
+            expect(getBrowserQueryUrlValue([])).toBe('');
         });
     });
 

--- a/src/Filter/modules/ListFilter/ListFilter.tsx
+++ b/src/Filter/modules/ListFilter/ListFilter.tsx
@@ -46,7 +46,7 @@ const ListFilter = (
             return undefined;
         }
     },
-    getBrowserQueryUrlValue: value => value && Array.from(value),
+    getBrowserQueryUrlValue: value => value ? Array.from(value).toString() : '',
     getDefaultFilterValue: () => new Set(options.map(item => item.value)),
     isDefaultFilterValue: value => {
         if (value) {

--- a/src/Filter/modules/ListFilter/__tests__/listFilter.test.js
+++ b/src/Filter/modules/ListFilter/__tests__/listFilter.test.js
@@ -73,10 +73,14 @@ describe('ListFilter', () => {
     describe('getBrowserQueryUrlValue', () => {
         const { getBrowserQueryUrlValue } = ListFilter(options, '', '');
 
-        it('returns the value provided', () => {
-            expect(getBrowserQueryUrlValue(new Set(['a']))).toStrictEqual(['a']);
-            expect(getBrowserQueryUrlValue(new Set([1]))).toStrictEqual([1]);
-            expect(getBrowserQueryUrlValue()).toBeUndefined();
+        it('returns a stringified array when truthy value is provided', () => {
+            expect(getBrowserQueryUrlValue(new Set(['a']))).toBe('a');
+            expect(getBrowserQueryUrlValue(new Set([1, 2]))).toBe('1,2');
+            expect(getBrowserQueryUrlValue(new Set([]))).toBe('');
+        });
+
+        it('returns an empty string when falsy value is provided', () => {
+            expect(getBrowserQueryUrlValue()).toBe('');
         });
     });
 

--- a/src/Filter/modules/MultiSelectFilter/MultiSelectFilter.tsx
+++ b/src/Filter/modules/MultiSelectFilter/MultiSelectFilter.tsx
@@ -43,7 +43,7 @@ const MultiSelectFilter = (
             return undefined;
         }
     },
-    getBrowserQueryUrlValue: (value) => value,
+    getBrowserQueryUrlValue: (value) => value ? String(value) : '',
     getDefaultFilterValue: () => [],
     isDefaultFilterValue: (value) => {
         if (value) {

--- a/src/Filter/modules/MultiSelectFilter/__tests__/multiSelectFilter.test.js
+++ b/src/Filter/modules/MultiSelectFilter/__tests__/multiSelectFilter.test.js
@@ -78,11 +78,14 @@ describe('MultiSelectFilter', () => {
     describe('getBrowserQueryUrlValue', () => {
         const { getBrowserQueryUrlValue } = MultiSelectFilter({}, {});
 
-        it('returns the value provided', () => {
-            const value = [];
-            expect(getBrowserQueryUrlValue(value)).toBe(value);
-            expect(getBrowserQueryUrlValue(1)).toBe(1);
-            expect(getBrowserQueryUrlValue()).toBeUndefined();
+        it('returns the stringified value when truthy value is provided', () => {
+            expect(getBrowserQueryUrlValue([])).toBe('');
+            expect(getBrowserQueryUrlValue(1)).toBe('1');
+        });
+
+        it('returns empty string when falsy value is provided', () => {
+            expect(getBrowserQueryUrlValue()).toBe('');
+            expect(getBrowserQueryUrlValue(false)).toBe('');
         });
     });
 

--- a/src/Filter/modules/RadioFilter/RadioFilter.tsx
+++ b/src/Filter/modules/RadioFilter/RadioFilter.tsx
@@ -19,12 +19,12 @@ import { RadioGroupContainer } from './radioFilterStyles';
 const RadioFilter = (
     { initialValue, defaultValue, options, label, description }: RadioFilterProps,
     radioFilterOptions: RadioFilterOptions = {}
-): FilterModule<string> => ({
+): FilterModule<string | number> => ({
     getApiQueryUrl: (key, value) => {
         return value !== defaultValue ? `&${key}=${value}` : '';
     },
     getApiPostBody: (key, value) => (value ? { [key]: value } : undefined),
-    getBrowserQueryUrlValue: (value) => value,
+    getBrowserQueryUrlValue: (value) => value ? String(value) : '',
     getDefaultFilterValue: () => defaultValue,
     isDefaultFilterValue: (value) => value === defaultValue,
     getFilterBarLabel: (value) => {

--- a/src/Filter/modules/RadioFilter/__tests__/radioFilter.test.js
+++ b/src/Filter/modules/RadioFilter/__tests__/radioFilter.test.js
@@ -65,10 +65,14 @@ describe('RadioFilter', () => {
     describe('getBrowserQueryUrlValue', () => {
         const { getBrowserQueryUrlValue } = RadioFilter({}, {});
 
-        it('returns the value provided', () => {
+        it('returns the stringified value when truthy value is provided', () => {
             expect(getBrowserQueryUrlValue('a')).toBe('a');
-            expect(getBrowserQueryUrlValue(1)).toBe(1);
-            expect(getBrowserQueryUrlValue()).toBeUndefined();
+            expect(getBrowserQueryUrlValue(1)).toBe('1');
+        });
+
+        it('returns empty string when falsy value is provided', () => {
+            expect(getBrowserQueryUrlValue()).toBe('');
+            expect(getBrowserQueryUrlValue(false)).toBe('');
         });
     });
 

--- a/src/Filter/modules/SingleSelectFilter/SelectOverlay.tsx
+++ b/src/Filter/modules/SingleSelectFilter/SelectOverlay.tsx
@@ -5,7 +5,7 @@ import theme from 'src/styles/theme';
 import { SelectOption } from 'src/types/global';
 import { ThemeProvider } from '@emotion/react';
 
-export type SelectOverlayOption = SelectOption<string>;
+export type SelectOverlayOption = SelectOption<string | number>;
 
 /**
  * `SelectProps` are the props to be provided to the Select

--- a/src/Filter/modules/SingleSelectFilter/SingleSelectFilter.tsx
+++ b/src/Filter/modules/SingleSelectFilter/SingleSelectFilter.tsx
@@ -27,7 +27,7 @@ const SingleSelectFilter = (
         required
     }: SingleSelectFilterProps,
     singleSelectFilterOptions: SingleSelectFilterOptions = {}
-): FilterModule<string> => ({
+): FilterModule<string | number> => ({
     getApiQueryUrl: (key, value) => {
         return value ? `&${key}=${encodeURIComponent(value)}` : '';
     },
@@ -35,8 +35,8 @@ const SingleSelectFilter = (
     getBrowserQueryUrlValue: value => value,
     getDefaultFilterValue: () => '',
     isDefaultFilterValue: value => value === '',
-    getFilterBarLabel: value => (filterLabelPrefix ? `${filterLabelPrefix}: ${value}` : value),
-    getFilterSectionLabel: value => value,
+    getFilterBarLabel: value => (filterLabelPrefix ? `${filterLabelPrefix}: ${value}` : String(value)),
+    getFilterSectionLabel: value => String(value),
     parseInitialFilterValue: (browserQueryUrlValue: string) => browserQueryUrlValue || (initialValue ? String(initialValue) : ''),
     renderComponent: ({ name, value, update }) => {
         // shallow copy of options to not mutate the original

--- a/src/Filter/modules/SingleSelectFilter/SingleSelectFilter.tsx
+++ b/src/Filter/modules/SingleSelectFilter/SingleSelectFilter.tsx
@@ -32,7 +32,7 @@ const SingleSelectFilter = (
         return value ? `&${key}=${encodeURIComponent(value)}` : '';
     },
     getApiPostBody: (key, value) => (value ? { [key]: value } : undefined),
-    getBrowserQueryUrlValue: value => value,
+    getBrowserQueryUrlValue: value => value ? String(value) : '',
     getDefaultFilterValue: () => '',
     isDefaultFilterValue: value => value === '',
     getFilterBarLabel: value => (filterLabelPrefix ? `${filterLabelPrefix}: ${value}` : String(value)),

--- a/src/Filter/modules/SingleSelectFilter/__tests__/singleSelectFilter.test.js
+++ b/src/Filter/modules/SingleSelectFilter/__tests__/singleSelectFilter.test.js
@@ -94,16 +94,18 @@ describe('SingleSelectFilter', () => {
             expect(getFilterBarLabel(SINGLE_SELECT_FILTER_OPTIONS[0].value)).toBe(`value: ${SINGLE_SELECT_FILTER_OPTIONS[0].value}`);
         });
         
-        it('returns value when filterLabelPrefix is falsy', () => {
+        it('returns stringified value when filterLabelPrefix is falsy', () => {
             const { getFilterBarLabel } = SingleSelectFilter({ options: SINGLE_SELECT_FILTER_OPTIONS }, {});
             expect(getFilterBarLabel(SINGLE_SELECT_FILTER_OPTIONS[0].value)).toBe(SINGLE_SELECT_FILTER_OPTIONS[0].value);
+            expect(getFilterBarLabel(1)).toBe('1');
         });
     });
 
     describe('getFilterSectionLabel', () => {
-        it('returns value provided', () => {
+        it('returns stringified value provided', () => {
             const { getFilterSectionLabel } = SingleSelectFilter({ options: SINGLE_SELECT_FILTER_OPTIONS, filterLabelPrefix: 'value' }, {});
             expect(getFilterSectionLabel(SINGLE_SELECT_FILTER_OPTIONS[0].value)).toBe(SINGLE_SELECT_FILTER_OPTIONS[0].value);
+            expect(getFilterSectionLabel(1)).toBe('1');
         });
     });
 

--- a/src/Filter/modules/SingleSelectFilter/__tests__/singleSelectFilter.test.js
+++ b/src/Filter/modules/SingleSelectFilter/__tests__/singleSelectFilter.test.js
@@ -61,10 +61,14 @@ describe('SingleSelectFilter', () => {
     describe('getBrowserQueryUrlValue', () => {
         const { getBrowserQueryUrlValue } = SingleSelectFilter({}, {});
 
-        it('returns the value provided', () => {
+        it('returns stringified value when truthy value is provided', () => {
             expect(getBrowserQueryUrlValue('a')).toBe('a');
-            expect(getBrowserQueryUrlValue(1)).toBe(1);
-            expect(getBrowserQueryUrlValue()).toBeUndefined();
+            expect(getBrowserQueryUrlValue(1)).toBe('1');
+        });
+
+        it('returns empty string when falsy value is provided', () => {
+            expect(getBrowserQueryUrlValue()).toBe('');
+            expect(getBrowserQueryUrlValue(false)).toBe('');
         });
     });
 

--- a/src/Filter/types/index.ts
+++ b/src/Filter/types/index.ts
@@ -56,7 +56,7 @@ export interface FilterModule<T> {
     /**
      * Generates the url query param value(s) for saving filter value(s) in the browser address bar (key is automatic).
      */
-    getBrowserQueryUrlValue(value: T): unknown;
+    getBrowserQueryUrlValue(value: T): string;
     /**
      * Returns filter value that is set when filter is cleared.
      */

--- a/src/Filter/types/index.ts
+++ b/src/Filter/types/index.ts
@@ -56,7 +56,7 @@ export interface FilterModule<T> {
     /**
      * Generates the url query param value(s) for saving filter value(s) in the browser address bar (key is automatic).
      */
-    getBrowserQueryUrlValue(value: T): any;
+    getBrowserQueryUrlValue(value: T): unknown;
     /**
      * Returns filter value that is set when filter is cleared.
      */

--- a/src/Filter/types/index.ts
+++ b/src/Filter/types/index.ts
@@ -56,7 +56,7 @@ export interface FilterModule<T> {
     /**
      * Generates the url query param value(s) for saving filter value(s) in the browser address bar (key is automatic).
      */
-    getBrowserQueryUrlValue(value: T): string | string[] | null | undefined;
+    getBrowserQueryUrlValue(value: T): any;
     /**
      * Returns filter value that is set when filter is cleared.
      */

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -21,14 +21,14 @@ import {
      * and whether the individual option is `disabled`.
      */
     options: {
-        value: string;
+        value: string | number;
         label: string | ReactElement;
         disabled?: boolean;
     }[];
     /**
      * The value of the selected radio button.
      */
-    value: string;
+    value: string | number;
     /**
      * HTML input element disabled prop.
      */


### PR DESCRIPTION
This PR allows numbers to be a valid input and return type when using the SingleSelect and Radio Filter modules. This also allows the FilterModule.getBrowserQueryUrlValue to return any type since parsing the value can truly return any value depending on how the user wants to implement the function.