### PR TITLE
Fix list filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.59.3",
+  "version": "0.59.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.59.3",
+  "version": "0.59.4",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/Filter/modules/AdditionalJSONFilter/AdditionalJSONFilter.tsx
+++ b/src/Filter/modules/AdditionalJSONFilter/AdditionalJSONFilter.tsx
@@ -19,7 +19,7 @@ const AdditionalJSONFilter = (additionalJSONFilterOptions: AdditionalJSONFilterO
     inputHidden: true,
     getApiQueryUrl: () => '',
     getApiPostBody: (_, value) => value,
-    getBrowserQueryUrlValue: value => isActualValue(value) ? JSON.stringify(value) : '',
+    getBrowserQueryUrlValue: value => isActualValue(value) ? JSON.stringify(value) : undefined,
     getDefaultFilterValue: () => undefined,
     isDefaultFilterValue: value => !isActualValue(value),
     getFilterBarLabel: value => (value ? ADDITIONAL_JSON_FILTER_BAR_LABEL : ''),

--- a/src/Filter/modules/AdditionalJSONFilter/__tests__/additionalJSONFilter.test.js
+++ b/src/Filter/modules/AdditionalJSONFilter/__tests__/additionalJSONFilter.test.js
@@ -41,10 +41,10 @@ describe('AdditionalJSONFilter', () => {
             expect(getBrowserQueryUrlValue([1])).toBe(JSON.stringify([1]));
         });
 
-        it('returns empty string if value is not an actual value', () => {
-            expect(getBrowserQueryUrlValue()).toBe('');
-            expect(getBrowserQueryUrlValue(1)).toBe('');
-            expect(getBrowserQueryUrlValue([])).toBe('');
+        it('returns undefined if value is not an actual value', () => {
+            expect(getBrowserQueryUrlValue()).toBeUndefined();
+            expect(getBrowserQueryUrlValue(1)).toBeUndefined();
+            expect(getBrowserQueryUrlValue([])).toBeUndefined();
         });
     });
 

--- a/src/Filter/modules/ListFilter/ListFilter.tsx
+++ b/src/Filter/modules/ListFilter/ListFilter.tsx
@@ -46,7 +46,7 @@ const ListFilter = (
             return undefined;
         }
     },
-    getBrowserQueryUrlValue: value => value ? Array.from(value).toString() : '',
+    getBrowserQueryUrlValue: value => value && Array.from(value),
     getDefaultFilterValue: () => new Set(options.map(item => item.value)),
     isDefaultFilterValue: value => {
         if (value) {

--- a/src/Filter/modules/ListFilter/__tests__/listFilter.test.js
+++ b/src/Filter/modules/ListFilter/__tests__/listFilter.test.js
@@ -73,14 +73,14 @@ describe('ListFilter', () => {
     describe('getBrowserQueryUrlValue', () => {
         const { getBrowserQueryUrlValue } = ListFilter(options, '', '');
 
-        it('returns a stringified array when truthy value is provided', () => {
-            expect(getBrowserQueryUrlValue(new Set(['a']))).toBe('a');
-            expect(getBrowserQueryUrlValue(new Set([1, 2]))).toBe('1,2');
-            expect(getBrowserQueryUrlValue(new Set([]))).toBe('');
+        it('returns an array from value when truthy value is provided', () => {
+            expect(getBrowserQueryUrlValue(new Set(['a']))).toMatchObject(['a']);
+            expect(getBrowserQueryUrlValue(new Set([1, 2]))).toMatchObject([1, 2]);
+            expect(getBrowserQueryUrlValue(new Set([]))).toMatchObject([]);
         });
 
-        it('returns an empty string when falsy value is provided', () => {
-            expect(getBrowserQueryUrlValue()).toBe('');
+        it('returns undefined when falsy value is provided', () => {
+            expect(getBrowserQueryUrlValue()).toBeUndefined();
         });
     });
 

--- a/src/Filter/modules/MultiSelectFilter/MultiSelectFilter.tsx
+++ b/src/Filter/modules/MultiSelectFilter/MultiSelectFilter.tsx
@@ -45,7 +45,7 @@ const MultiSelectFilter = (
             return undefined;
         }
     },
-    getBrowserQueryUrlValue: (value) => value ? String(value) : '',
+    getBrowserQueryUrlValue: (value) => value,
     getDefaultFilterValue: () => [],
     isDefaultFilterValue: (value) => {
         if (value) {

--- a/src/Filter/modules/MultiSelectFilter/__tests__/multiSelectFilter.test.js
+++ b/src/Filter/modules/MultiSelectFilter/__tests__/multiSelectFilter.test.js
@@ -78,14 +78,10 @@ describe('MultiSelectFilter', () => {
     describe('getBrowserQueryUrlValue', () => {
         const { getBrowserQueryUrlValue } = MultiSelectFilter({}, {});
 
-        it('returns the stringified value when truthy value is provided', () => {
-            expect(getBrowserQueryUrlValue([])).toBe('');
-            expect(getBrowserQueryUrlValue(1)).toBe('1');
-        });
-
-        it('returns empty string when falsy value is provided', () => {
-            expect(getBrowserQueryUrlValue()).toBe('');
-            expect(getBrowserQueryUrlValue(false)).toBe('');
+        it('returns the provided value when truthy value is provided', () => {
+            expect(getBrowserQueryUrlValue([])).toMatchObject([]);
+            expect(getBrowserQueryUrlValue(1)).toBe(1);
+            expect(getBrowserQueryUrlValue()).toBeUndefined();
         });
     });
 

--- a/src/Filter/modules/RadioFilter/RadioFilter.tsx
+++ b/src/Filter/modules/RadioFilter/RadioFilter.tsx
@@ -24,7 +24,7 @@ const RadioFilter = (
         return value !== defaultValue ? `&${key}=${value}` : '';
     },
     getApiPostBody: (key, value) => (value ? { [key]: value } : undefined),
-    getBrowserQueryUrlValue: (value) => value ? String(value) : '',
+    getBrowserQueryUrlValue: (value) => value,
     getDefaultFilterValue: () => defaultValue,
     isDefaultFilterValue: (value) => value === defaultValue,
     getFilterBarLabel: (value) => {

--- a/src/Filter/modules/RadioFilter/__tests__/radioFilter.test.js
+++ b/src/Filter/modules/RadioFilter/__tests__/radioFilter.test.js
@@ -65,14 +65,10 @@ describe('RadioFilter', () => {
     describe('getBrowserQueryUrlValue', () => {
         const { getBrowserQueryUrlValue } = RadioFilter({}, {});
 
-        it('returns the stringified value when truthy value is provided', () => {
+        it('returns the value provided', () => {
             expect(getBrowserQueryUrlValue('a')).toBe('a');
-            expect(getBrowserQueryUrlValue(1)).toBe('1');
-        });
-
-        it('returns empty string when falsy value is provided', () => {
-            expect(getBrowserQueryUrlValue()).toBe('');
-            expect(getBrowserQueryUrlValue(false)).toBe('');
+            expect(getBrowserQueryUrlValue(1)).toBe(1);
+            expect(getBrowserQueryUrlValue()).toBe(undefined);
         });
     });
 

--- a/src/Filter/modules/SingleSelectFilter/SingleSelectFilter.tsx
+++ b/src/Filter/modules/SingleSelectFilter/SingleSelectFilter.tsx
@@ -32,7 +32,7 @@ const SingleSelectFilter = (
         return value ? `&${key}=${encodeURIComponent(value)}` : '';
     },
     getApiPostBody: (key, value) => (value ? { [key]: value } : undefined),
-    getBrowserQueryUrlValue: value => value ? String(value) : '',
+    getBrowserQueryUrlValue: value => value,
     getDefaultFilterValue: () => '',
     isDefaultFilterValue: value => value === '',
     getFilterBarLabel: value => (filterLabelPrefix ? `${filterLabelPrefix}: ${value}` : String(value)),

--- a/src/Filter/modules/SingleSelectFilter/__tests__/singleSelectFilter.test.js
+++ b/src/Filter/modules/SingleSelectFilter/__tests__/singleSelectFilter.test.js
@@ -61,14 +61,10 @@ describe('SingleSelectFilter', () => {
     describe('getBrowserQueryUrlValue', () => {
         const { getBrowserQueryUrlValue } = SingleSelectFilter({}, {});
 
-        it('returns stringified value when truthy value is provided', () => {
+        it('returns the provided value when truthy value is provided', () => {
             expect(getBrowserQueryUrlValue('a')).toBe('a');
-            expect(getBrowserQueryUrlValue(1)).toBe('1');
-        });
-
-        it('returns empty string when falsy value is provided', () => {
-            expect(getBrowserQueryUrlValue()).toBe('');
-            expect(getBrowserQueryUrlValue(false)).toBe('');
+            expect(getBrowserQueryUrlValue(1)).toBe(1);
+            expect(getBrowserQueryUrlValue()).toBeUndefined();
         });
     });
 

--- a/src/Filter/types/index.ts
+++ b/src/Filter/types/index.ts
@@ -55,8 +55,11 @@ export interface FilterModule<T> {
     getApiPostBody(key: string, value: T): FilterPostBody | null | undefined;
     /**
      * Generates the url query param value(s) for saving filter value(s) in the browser address bar (key is automatic).
+     * **Note: The output value here can be any valid object
+     * of type `Record<string, any>` as it will be stringified in the useFilter hook using the query-string library
+     * defaults (https://github.com/sindresorhus/query-string)**.
      */
-    getBrowserQueryUrlValue(value: T): string;
+    getBrowserQueryUrlValue(value: T): unknown;
     /**
      * Returns filter value that is set when filter is cleared.
      */

--- a/src/Filter/util/filterHooksUtil.tsx
+++ b/src/Filter/util/filterHooksUtil.tsx
@@ -59,7 +59,9 @@ export const getCurrentBrowserQueryParams = (location: Location, excludeKeys?: s
 
 /**
  * Get browser query params to save in browser address bar
- * using current filter values.
+ * using current filter values. **Note: Each filter value can be any valid object
+ * of type `Record<string, any>` as it will be stringified in the useFilter hook using the query-string library
+ * defaults (https://github.com/sindresorhus/query-string)**.
  */
 export const getFilterBrowserQueryParams = (filters: FilterSet, values: FilterValues): ParsedQuery => {
     const urlValues: FilterValues = {};


### PR DESCRIPTION
This PR addresses an issue where the values output by the `getBrowserQueryUrlValue` method of some filter modules was now incorrect. If approved, this will close #142.

![image](https://user-images.githubusercontent.com/80778550/128879828-1ecabeb8-34f9-44b5-801b-a3f35e4f55a5.png)
