### PR TITLE
Increase step function test coverage - Part 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.65.1",
+  "version": "0.66.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.65.1",
+  "version": "0.66.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/StepFunctionGraph/GraphRenderer.ts
+++ b/src/StepFunctionGraph/GraphRenderer.ts
@@ -175,8 +175,9 @@ export const handleParallel = (
 
     const paths = DigraphDFS.getAllDfsPaths(graph.getAdjacencyMatrix(), [vertex]);
     const parallelNodeMatrix = DigraphDFS.getVerticesAtDepthFromPaths(paths, exclusionArray);
-
-    const baselineNode = drawn.get(parallelNodeMatrix[0][0]);
+    const flatMatrix: number[] = parallelNodeMatrix.flat();
+    const topLeftNode = flatMatrix.find(vertex => drawn.get(vertex)) ?? flatMatrix[0];
+    const baselineNode = drawn.get(topLeftNode);
     const baselineX = baselineNode ? baselineNode.x : 0;
 
     // Calculate the start of the Parallel box's contents so we can position it
@@ -199,7 +200,6 @@ export const handleParallel = (
 
     // Calculate the lower bounds of the Parallel content
     const lastDepth = parallelNodeMatrix[parallelNodeMatrix.length - 1];
-    const topLeftNode = parallelNodeMatrix[0][0];
     const bottomRightNode = lastDepth[lastDepth.length - 1];
 
     const topLeft = drawn.get(topLeftNode);
@@ -283,7 +283,8 @@ export const getX = (
         false;
 
     // Helpful to know if we're in a group so we can try to determine if we're positioning by previous
-    const isInPreviousGroup = getGroupIndex(groups, vertex) === getGroupIndex(groups, previousVertex);
+    const currentGroupIndex = getGroupIndex(groups, vertex);
+    const isInPreviousGroup = currentGroupIndex === getGroupIndex(groups, previousVertex);
     const parentNode = indegrees[indegrees.length - 1];
     const flattened = ([] as number[]).concat(...groups);
 
@@ -315,15 +316,18 @@ export const getX = (
             isParallelNext
         );
 
+    const currentGroup = groups[currentGroupIndex];
+    const rangeLength = groups.length > 1 ? currentGroup.length : flattened.length;
+
     // The rangePosition tells us where we need to draw in a range when positioning by previous
     // eslint-disable-next-line no-nested-ternary
     let rangePosition = ~previousEnd ?
-        previousEnd + (range / flattened.length - 1) :
+        previousEnd + (range / rangeLength) :
         (flattened.length > 1) ?
             parentX - (range / 2) + (nodeWidth / 2):
-            (nodeWidth / 4);
+            (canvasWidth / centerDivision);
 
-    if (!~previousEnd && flattened.length > 2) {
+    if (!~previousEnd && groups.length > 1) {
         rangePosition /= 2;
     }
 
@@ -352,7 +356,7 @@ export const getX = (
         const drawnPreviousNode = drawn.get(previousVertex);
 
         if (
-            previousIndegreeType === WorkFlowType.PARALLEL &&
+            (previousIndegreeType === WorkFlowType.PARALLEL || previousIndegreeType === WorkFlowType.MAP) &&
             parentType !== WorkFlowType.PARALLEL ||
             isDelayed
         ) {
@@ -360,7 +364,7 @@ export const getX = (
             if (delayed.filter(d => d[4] === vertex).length > 0 && drawnPreviousIndegree) {
                 if (previousIndegreeType === WorkFlowType.PARALLEL) {
                     rangePosition = drawnPreviousIndegree.collisionBox.right.x + (nodeWidth / 2) + X_OFFSET;
-                } else if(drawnPreviousNode) {
+                } else if (drawnPreviousNode) {
                     rangePosition = drawnPreviousNode.collisionBox.right.x + (nodeWidth / 2) + X_OFFSET;
                 }
             } else {
@@ -368,6 +372,10 @@ export const getX = (
                 return null;
             }
         }
+    }
+
+    if (positionByPrevious && parentType === WorkFlowType.MAP) {
+        positionByParent = false;
     }
 
     let calculatedX;
@@ -436,7 +444,9 @@ export function renderVertex(
 
     // We don't need to offset a lone node at any given depth
     const xOffset = flattened.length > 1 ? X_OFFSET : 0;
-    const range = getRange(flattened, xOffset, graph);
+    const currentGroupIndex = getGroupIndex(groups, vertex);
+    const currentGroup = groups[currentGroupIndex];
+    const range = getRange(currentGroup, xOffset, graph);
 
     const x = getX(
         groups,

--- a/src/StepFunctionGraph/GraphRenderer.ts
+++ b/src/StepFunctionGraph/GraphRenderer.ts
@@ -335,7 +335,7 @@ export const getX = (
     // The rangePosition tells us where we need to draw in a range when positioning by previous
     // eslint-disable-next-line no-nested-ternary
     let rangePosition = ~previousEnd ?
-        previousEnd + (range / rangeLength) :
+        previousEnd + X_OFFSET :
         (flattened.length > 1) ?
             parentX - (range / 2) + (nodeWidth / 2):
             (canvasWidth / centerDivision);

--- a/src/StepFunctionGraph/GraphRenderer.ts
+++ b/src/StepFunctionGraph/GraphRenderer.ts
@@ -336,7 +336,7 @@ export const getX = (
     // eslint-disable-next-line no-nested-ternary
     let rangePosition = ~previousEnd ?
         previousEnd + X_OFFSET : // there is a previous end, we just need to add space between
-        (flattened.length > 1) ? // there is no previous end
+        (rangeLength > 1) ? // there is no previous end
             parentX - (range / 2) + (nodeWidth / 2) : // no previous end and there is more than one total node in the row
             (canvasWidth / centerDivision); // no previous end but there is one node in the row so the canvas center is used
 

--- a/src/StepFunctionGraph/GraphRenderer.ts
+++ b/src/StepFunctionGraph/GraphRenderer.ts
@@ -406,7 +406,7 @@ export const getX = (
     } else if (positionByPrevious && !positionByParent) {
         calculatedX = rangePosition;
     } else if (positionByParent) {
-        calculatedX = isParallelNext ? parallelRange : parentX;
+        calculatedX = isParallelNext && !isNaN(parallelRange) ? parallelRange : parentX;
     } else {
         calculatedX = rangePosition;
     }
@@ -471,7 +471,7 @@ export function renderVertex(
     // We don't need to offset a lone node at any given depth
     const xOffset = flattened.length > 1 ? X_OFFSET : 0;
     const currentGroupIndex = getGroupIndex(groups, vertex);
-    const currentGroup = groups[currentGroupIndex];
+    const currentGroup = groups[currentGroupIndex] ?? [];
     const range = getRange(currentGroup, xOffset, graph);
 
     const x = getX(

--- a/src/StepFunctionGraph/GraphRenderer.ts
+++ b/src/StepFunctionGraph/GraphRenderer.ts
@@ -335,11 +335,12 @@ export const getX = (
     // The rangePosition tells us where we need to draw in a range when positioning by previous
     // eslint-disable-next-line no-nested-ternary
     let rangePosition = ~previousEnd ?
-        previousEnd + X_OFFSET :
-        (flattened.length > 1) ?
-            parentX - (range / 2) + (nodeWidth / 2):
-            (canvasWidth / centerDivision);
+        previousEnd + X_OFFSET : // there is a previous end, we just need to add space between
+        (flattened.length > 1) ? // there is no previous end
+            parentX - (range / 2) + (nodeWidth / 2) : // no previous end and there is more than one total node in the row
+            (canvasWidth / centerDivision); // no previous end but there is one node in the row so the canvas center is used
 
+    // Adjust the start position for a row left if there are multiple groups and no starting position with which to position
     if (!~previousEnd && groups.length > 1) {
         rangePosition /= 2;
     }

--- a/src/StepFunctionGraph/__tests__/graphRenderer.test.ts
+++ b/src/StepFunctionGraph/__tests__/graphRenderer.test.ts
@@ -1,15 +1,16 @@
 import 'jest-canvas-mock';
 import { CANVAS_DEFAULTS, graphContext } from './utils/graphTestUtils.util';
 import { JSONBuilderUtil } from './utils/JSONBuilder.util';
-import { getX, X_OFFSET } from '../GraphRenderer';
+import { getX, getY, renderVertex, X_OFFSET } from '../GraphRenderer';
 import { WorkFlowType } from '../StepFunctionUtil';
 import { NodeDimensions } from '../GraphUtil';
+import * as CanvasUtilModule from '../canvasUtil';
 
 describe('graphRenderer', () => {
     const CENTER = CANVAS_DEFAULTS.width / 4;
     const NODE_WIDTH = 50;
 
-    let ctx;
+    let ctx: CanvasRenderingContext2D | null;
 
     beforeEach(() => {
         ctx = document.createElement('canvas').getContext('2d');
@@ -23,10 +24,10 @@ describe('graphRenderer', () => {
                 .addTask('EndNode', undefined, true)
                 .getJson();
 
-            const { drawn, graph, groups } = graphContext(json);
+            const { drawn, graph, groups: x1Groups } = graphContext(json, 1);
 
             const x1 = getX(
-                groups,
+                x1Groups,
                 1,
                 50,
                 CANVAS_DEFAULTS.width,
@@ -40,8 +41,10 @@ describe('graphRenderer', () => {
                 {}
             );
 
+            const { groups: x2Groups } = graphContext(json, 2);
+
             const x2 = getX(
-                groups,
+                x2Groups,
                 2,
                 50,
                 CANVAS_DEFAULTS.width,
@@ -55,8 +58,10 @@ describe('graphRenderer', () => {
                 {}
             );
 
+            const { groups: x3Groups } = graphContext(json, 3);
+
             const x3 = getX(
-                groups,
+                x3Groups,
                 3,
                 50,
                 CANVAS_DEFAULTS.width,
@@ -82,9 +87,9 @@ describe('graphRenderer', () => {
                 ], undefined, true)
                 .getJson();
 
-            const { drawn, graph, groups } = graphContext(json);
+            const { drawn, graph, groups } = graphContext(json, 1);
 
-            drawn.set(1, { nodeType: WorkFlowType.PARALLEL } as NodeDimensions);
+            drawn.set(1, {nodeType: WorkFlowType.PARALLEL} as NodeDimensions);
 
             const x = getX(
                 groups,
@@ -115,9 +120,9 @@ describe('graphRenderer', () => {
                 .addSuccess('EndNode', undefined, true)
                 .getJson();
 
-            const { drawn, graph, groups } = graphContext(json);
+            const { drawn, graph, groups } = graphContext(json, 2);
 
-            drawn.set(1, { nodeType: WorkFlowType.CHOICE, x: CENTER } as NodeDimensions);
+            drawn.set(1, {nodeType: WorkFlowType.CHOICE, x: CENTER} as NodeDimensions);
 
             const x1 = getX(
                 groups,
@@ -134,7 +139,7 @@ describe('graphRenderer', () => {
                 {}
             );
 
-            drawn.set(2, { nodeType: WorkFlowType.TASK, x: x1 } as NodeDimensions);
+            drawn.set(2, {nodeType: WorkFlowType.TASK, x: x1} as NodeDimensions);
 
             const previousEnd = x1 as number + 50;
 
@@ -155,8 +160,240 @@ describe('graphRenderer', () => {
 
             const expectedX2 = previousEnd + (NODE_WIDTH / 2) + X_OFFSET;
 
-            expect(x1).toBe(CENTER);
-            expect(x2).toBe(expectedX2);
+            expect(x1).toBe(275); // calculated as the range position
+            expect(x2).toBe(expectedX2); // calculated as the newPositionByPrevious
+        });
+
+        it('should offset the node if the previous parent is a Map node to account for the Map width', () => {
+            const json = new JSONBuilderUtil()
+                .addParallel('ParallelNode', [
+                    new JSONBuilderUtil()
+                        .addMap('MapNode', new JSONBuilderUtil().addTask('M1').getJson())
+                        .getJson(),
+                    new JSONBuilderUtil()
+                        .addTask('AfterMap', 'EndNode')
+                        .getJson()
+                ], 'EndNode')
+                .addTask('EndNode', undefined, true)
+                .getJson();
+
+            const { drawn, graph, groups } = graphContext(json, 1);
+
+            const x = getX(
+                groups,
+                4,
+                50,
+                CANVAS_DEFAULTS.width,
+                0,
+                100,
+                3,
+                graph,
+                drawn,
+                6,
+                [],
+                {}
+            );
+
+            const expected = 100 + (NODE_WIDTH / 2) + X_OFFSET + (X_OFFSET / 2);
+
+            expect(x).toBe(expected);
+        });
+    });
+
+    describe('getY', () => {
+        it('should return a y value given a depth and node height', () => {
+            const y1 = getY(0, 50);
+            const expectedY1 = 75;
+
+            const y2 = getY(1, 50);
+            const expectedY2 = 200;
+
+            const y3 = getY(2, 50);
+            const expectedY3 = 325;
+
+            const y4 = getY(3, 100);
+            const expectedY4 = 600;
+
+            const y5 = getY(4, 0);
+            const expectedY5 = 375;
+
+            expect(y1).toBe(expectedY1);
+            expect(y2).toBe(expectedY2);
+            expect(y3).toBe(expectedY3);
+            expect(y4).toBe(expectedY4);
+            expect(y5).toBe(expectedY5);
+        });
+    });
+
+    describe('renderVertex', () => {
+        const json = new JSONBuilderUtil()
+            .addTask('StartNode', 'ParallelNode')
+            .addParallel('ParallelNode', [
+                new JSONBuilderUtil().addTask('P1').getJson(),
+                new JSONBuilderUtil().addTask('P2').getJson()
+            ], 'MapNode')
+            .addMap('MapNode', new JSONBuilderUtil().addTask('M1').getJson(), 'ChoiceNode')
+            .addChoice('ChoiceNode', [
+                JSONBuilderUtil.getChoiceForAdd('EndNode')
+            ])
+            .addSuccess('EndNode', undefined, true)
+            .getJson();
+
+        let drawTerminalNodeSpy: jest.SpyInstance;
+        let drawStepNodeSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            drawTerminalNodeSpy = jest.spyOn(CanvasUtilModule, 'drawTerminalNode');
+            drawStepNodeSpy = jest.spyOn(CanvasUtilModule, 'drawStepNode');
+        });
+
+        it('should call Start and End node draw functions', () => {
+            const { drawn, graph, groups, verticesAtDepth } = graphContext(json);
+            const startDepth = verticesAtDepth[0];
+            const endDepth = [verticesAtDepth.length - 1];
+
+            renderVertex(
+                startDepth,
+                0,
+                drawn,
+                graph,
+                0,
+                groups,
+                NODE_WIDTH,
+                9,
+                0,
+                [],
+                ctx as CanvasRenderingContext2D,
+                []
+            );
+
+            expect(drawTerminalNodeSpy).toHaveBeenCalledTimes(1);
+
+            const { groups: endGroups } = graphContext(json, verticesAtDepth.length - 1);
+
+            renderVertex(
+                endDepth,
+                0,
+                drawn,
+                graph,
+                9,
+                endGroups,
+                NODE_WIDTH,
+                9,
+                6,
+                [],
+                ctx as CanvasRenderingContext2D,
+                []
+            );
+
+            expect(drawTerminalNodeSpy).toHaveBeenCalledTimes(2);
+            expect(drawStepNodeSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it('should call the Task, Choice, and unknown node draw function', () => {
+            // Task Node
+            const { drawn, graph, groups, verticesAtDepth } = graphContext(json, 1);
+
+            renderVertex(
+                verticesAtDepth[1],
+                0,
+                drawn,
+                graph,
+                1,
+                groups,
+                NODE_WIDTH,
+                9,
+                1,
+                [],
+                ctx as CanvasRenderingContext2D,
+                []
+            );
+
+            expect(drawStepNodeSpy).toHaveBeenCalledTimes(1);
+
+            // Choice node
+            const { groups: choiceGroups } = graphContext(json, 4);
+
+            renderVertex(
+                verticesAtDepth[4],
+                0,
+                drawn,
+                graph,
+                7,
+                choiceGroups,
+                NODE_WIDTH,
+                9,
+                4,
+                [],
+                ctx as CanvasRenderingContext2D,
+                []
+            );
+
+            expect(drawStepNodeSpy).toHaveBeenCalledTimes(2);
+
+            const unknownNodeJson = new JSONBuilderUtil()
+                .addTask('UnknownNode', undefined, true)
+                .editNode('UnknownNode', { Type: 'Unknown' })
+                .getJson();
+
+            const { drawn: unknownDrawn, graph: unknownGraph, groups: unknownGroups } = graphContext(unknownNodeJson, 1);
+
+            renderVertex(
+                verticesAtDepth[1],
+                0,
+                unknownDrawn,
+                unknownGraph,
+                1,
+                unknownGroups,
+                NODE_WIDTH,
+                2,
+                1,
+                [],
+                ctx as CanvasRenderingContext2D,
+                []
+            );
+
+            expect(drawStepNodeSpy).toHaveBeenCalledTimes(3);
+            expect(drawTerminalNodeSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it('should not call any render functions when the node is Map or Parallel', () => {
+            const { drawn, graph, groups: parallelGroups, verticesAtDepth } = graphContext(json, 2);
+
+            renderVertex(
+                verticesAtDepth[2],
+                2,
+                drawn,
+                graph,
+                2,
+                parallelGroups,
+                NODE_WIDTH,
+                9,
+                2,
+                [],
+                ctx as CanvasRenderingContext2D,
+                []
+            );
+
+            const { groups: mapGroups } = graphContext(json, 3);
+
+            renderVertex(
+                verticesAtDepth[3],
+                1,
+                drawn,
+                graph,
+                5,
+                mapGroups,
+                NODE_WIDTH,
+                9,
+                3,
+                [],
+                ctx as CanvasRenderingContext2D,
+                []
+            );
+
+            expect(drawStepNodeSpy).toHaveBeenCalledTimes(0);
+            expect(drawTerminalNodeSpy).toHaveBeenCalledTimes(0);
         });
     });
 });

--- a/src/StepFunctionGraph/__tests__/graphUtil.test.ts
+++ b/src/StepFunctionGraph/__tests__/graphUtil.test.ts
@@ -490,7 +490,7 @@ describe('graphUtil', () => {
            expect(getNextVertex(1, graph)).toBe(2);
         });
 
-        it('should return -1 for the start, end, and a non-existent vertex', () => {
+        it('should return -1 for the start, and a non-existent vertex', () => {
             const json = new JSONBuilderUtil()
                 .addTask('StartNode', 'EndNode')
                 .addTask('EndNode', undefined, true)
@@ -499,8 +499,18 @@ describe('graphUtil', () => {
             const { graph } = graphContext(json);
 
             expect(getNextVertex(0, graph)).toBe(-1);
-            expect(getNextVertex(2, graph)).toBe(-1);
             expect(getNextVertex(10, graph)).toBe(-1);
+        });
+
+        it('should return the end vertex', () => {
+            const json = new JSONBuilderUtil()
+                .addTask('StartNode', 'EndNode')
+                .addTask('EndNode', undefined, true)
+                .getJson();
+
+            const { graph } = graphContext(json);
+
+            expect(getNextVertex(2, graph)).toBe(3);
         });
 
         it('should return -1 when vertex is not provided', () => {
@@ -587,7 +597,7 @@ describe('graphUtil', () => {
             expect(groupsAtDepth).toStrictEqual(expected);
         });
 
-        it('should return a matrix with a two groups when given a Parallel node and a task', () => {
+        it('should return a matrix with one group when given a Parallel node and a task', () => {
             const json = new JSONBuilderUtil()
                 .addTask('StartNode', 'ParallelNode')
                 .addParallel('ParallelNode', [
@@ -598,7 +608,10 @@ describe('graphUtil', () => {
 
             const { graph, verticesAtDepth } = graphContext(json);
             const groupsAtDepth = getGroupsAtDepth(verticesAtDepth[2], graph);
-            const expected = [[3], [2]];
+
+            // Parallel nodes aren't included in the groups, but instead a group is made when
+            // a Parallel node is encountered
+            const expected = [[3]];
 
             expect(groupsAtDepth).toStrictEqual(expected);
         });

--- a/src/StepFunctionGraph/__tests__/graphUtil.test.ts
+++ b/src/StepFunctionGraph/__tests__/graphUtil.test.ts
@@ -675,7 +675,7 @@ describe('graphUtil', () => {
 
     describe('redrawNode', () => {
         it('should draw a choice, task, or succeed (default case) node', () => {
-            const drawStepNodeSpy = spyOn(CanvasUtilModule, 'drawStepNode');
+            const drawStepNodeSpy = jest.spyOn(CanvasUtilModule, 'drawStepNode');
             const json = new JSONBuilderUtil()
                 .addTask('StartNode', 'Choice')
                 .addChoice('ChoiceNode', [
@@ -700,7 +700,7 @@ describe('graphUtil', () => {
         });
 
         it('should not draw a Parallel, Map, Start, or End node', () => {
-            const drawStepNodeSpy = spyOn(CanvasUtilModule, 'drawStepNode');
+            const drawStepNodeSpy = jest.spyOn(CanvasUtilModule, 'drawStepNode');
             const json = new JSONBuilderUtil()
                 .addTask('StartNode', 'ParallelNode')
                 .addParallel('ParallelNode', [
@@ -731,7 +731,7 @@ describe('graphUtil', () => {
         });
 
         it('should not draw when a node cannot be found in the graph', () => {
-            const drawStepNodeSpy = spyOn(CanvasUtilModule, 'drawStepNode');
+            const drawStepNodeSpy = jest.spyOn(CanvasUtilModule, 'drawStepNode');
             const json = new JSONBuilderUtil()
                 .addTask('StartNode', 'Choice')
                 .addChoice('ChoiceNode', [

--- a/src/StepFunctionGraph/__tests__/utils/JSONBuilder.util.ts
+++ b/src/StepFunctionGraph/__tests__/utils/JSONBuilder.util.ts
@@ -1,4 +1,4 @@
-export type NodeType = 'Task' | 'Success' | 'Choice' | 'Map' | 'Parallel';
+export type NodeType = 'Task' | 'Success' | 'Choice' | 'Map' | 'Parallel' | string;
 
 export interface JSONStateObject {
     Type?: NodeType;
@@ -85,7 +85,7 @@ export class JSONBuilderUtil {
         return this;
     }
 
-    editNode(state: string, content: JSONState): JSONBuilderUtil {
+    editNode(state: string, content: JSONStateObject): JSONBuilderUtil {
         const original = { ...this.json.States[state] };
 
         this.json.States[state] = {

--- a/src/StepFunctionGraph/__tests__/utils/graphTestUtils.util.ts
+++ b/src/StepFunctionGraph/__tests__/utils/graphTestUtils.util.ts
@@ -24,7 +24,7 @@ interface GraphContext {
     verticesAtDepth: number[][];
 }
 
-export const graphContext = (json: StepFunctionJSON): GraphContext => {
+export const graphContext = (json: StepFunctionJSON, groupDepth = 0): GraphContext => {
     const digraph = new Digraph();
     const graph = generateStepFunctionGraph(json, digraph);
     const drawn = new Map<number, NodeDimensions>();
@@ -33,7 +33,7 @@ export const graphContext = (json: StepFunctionJSON): GraphContext => {
     let verticesAtDepth: number[][] = DigraphDFS.getVerticesAtDepthFromPaths(traversals, [], true);
     verticesAtDepth = adjustDepthMatrix(verticesAtDepth, graph);
 
-    const groups: number[][] = getGroupsAtDepth(verticesAtDepth[0], graph);
+    const groups: number[][] = getGroupsAtDepth(verticesAtDepth[groupDepth], graph);
 
     return {
         drawn,


### PR DESCRIPTION
This PR adds tests and bug fixes for the graphRenderer, mainly focusing on getX and renderVertex. There is still much room for more coverage, but this PR was starting to get long so I stopped here for now.

Some bugs that were fixed:

- Removed excessive space between nodes within a Parallel box
- Nodes that can overlap (specifically a node after a Map since they are wider) now more intelligently position further away
- Maps drawn in the top-left of a Parallel won't default to the center of the screen now
- Parallel nodes that aren't part of a choice now render by parent correctly
- Nested Map and Parallel nodes now have correct Y depth values (the adjusting function was not recursive so only the top level of anything was moved up)