### PR TITLE
Modal Scroll Issue Fix #155

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.74.3",
+  "version": "0.74.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.74.3",
+  "version": "0.74.4",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useEffect, useMemo, useState } from 'react';
+import { FC, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { ReactComponent as CloseIcon } from './assets/closeIcon.svg';
 import Button from 'src/Button/Button';
 import theme from 'src/styles/theme';
@@ -118,6 +118,8 @@ const Modal: FC<ModalProps> = (props) => {
     const [portal, setPortal] = useState<HTMLElement | null>(null);
     const [dialogElement, setDialogElement] = useState<HTMLElement | null>(null);
     const [update, setUpdate] = useState<number>(0);
+    const [bodyOverflow, setBodyOverflow] = useState<string>('');
+    const bodyOverflowRef = useRef(false);
 
     useEffect(() => {
         const bodyElementHTMLCollection = document.getElementsByTagName('body');
@@ -173,6 +175,21 @@ const Modal: FC<ModalProps> = (props) => {
             portal.style.zIndex = `${theme?.zIndex?.modal}`;
         }
     }, [update]);
+
+    useEffect(() => {
+        if (document) {
+            if (!bodyOverflowRef.current) {
+                setBodyOverflow(document.body.style.overflow);
+                bodyOverflowRef.current = true;
+            }
+
+            isOpen ? document.body.style.overflow = 'hidden' : document.body.style.overflow = bodyOverflow;
+            return (() => {
+                document.body.style.overflow = bodyOverflow;
+            });
+        }
+    }, [isOpen]);
+
 
     const dialogNodeMounted = (node: HTMLDivElement) => {
         setDialogElement(node);


### PR DESCRIPTION
This PR will close #155. The scroll is hidden for the main content whenever the modal is active.

<img width="1440" alt="Screen Shot 2021-09-03 at 2 36 18 PM" src="https://user-images.githubusercontent.com/30271951/132052302-2bc6d273-9774-410f-97f1-9b3b529929a3.png">
When modals do not have scrollable (inner) content, the entire page behind the modal will scroll if the user uses the scroll wheel either hovering over the modal or the page itself. Scrolling should be blocked.