### PR TITLE
Textfilter number only support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.78.3",
+  "version": "0.79.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.78.3",
+  "version": "0.79.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/Filter/modules/TextFilter/TextFilter.tsx
+++ b/src/Filter/modules/TextFilter/TextFilter.tsx
@@ -1,23 +1,30 @@
 import TextSearch from './TextSearch';
-import { FilterModule, TextFilterOptions } from 'src/Filter/types';
+import { FilterModule, TextFilterOverrides } from 'src/Filter/types';
+
+export interface TextFilterOptions {
+    type?: 'text' | 'number';
+}
 
 /**
  * TextFilter Component
  * 
  * The TextFilter component is a text input control meant to be used as a keyword(s) search. While the default
  * behaviour should suffice, any valid `FilterModule` property (excluding description and label) can
- * be supplied via the `textFilterOptions` parameter to change how the filter looks and acts. TextFilter arguments include:
+ * be supplied via the `textFilterOverrides` parameter to change how the filter looks and acts. TextFilter arguments include:
  * 
  * `label` - The label to display for the text filter component.
  * 
  * `description` - The description/help text to display above the text filter component.
  * 
- * `textFilterOptions` - Any valid `FilterModule` property (excluding description and label)
+ * `textFilterOverrides` - Any valid `FilterModule` property (excluding description and label)
  * which will override default text filter behaviour.
+ * 
+ * `textFilterOptions` - Used to set additional textFilter options such as the type of text input.
  */
 const TextFilter = (
     label: string,
     description?: string,
+    textFilterOverrides: TextFilterOverrides = {},
     textFilterOptions: TextFilterOptions = {}
 ): FilterModule<string> => ({
     getApiQueryUrl: (key, value) => {
@@ -30,10 +37,12 @@ const TextFilter = (
     getFilterBarLabel: (value) => value,
     getFilterSectionLabel: (value) => value,
     parseInitialFilterValue: (browserQueryUrlValue: string) => browserQueryUrlValue || '',
-    renderComponent: ({ name, value, update }) => <TextSearch key={name} onChange={update} value={value} />,
-    ...textFilterOptions,
+    renderComponent: ({ name, value, update }) => (
+        <TextSearch key={name} onChange={update} value={value} type={textFilterOptions.type} />
+    ),
+    ...textFilterOverrides,
     description,
-    label,
+    label
 });
 
 export default TextFilter;

--- a/src/Filter/modules/TextFilter/TextSearch.tsx
+++ b/src/Filter/modules/TextFilter/TextSearch.tsx
@@ -3,10 +3,11 @@ import { StyledInput } from './textSearchStyles';
 
 interface TextSearchProps {
     onChange(text: string): void;
+    type?: 'text' | 'number';
     value: string;
 }
 
-const TextSearch: FC<TextSearchProps> = ({ onChange, value }) => {
+const TextSearch: FC<TextSearchProps> = ({ onChange, type = 'text', value }) => {
     const [text, setText] = useState('');
 
     useEffect(() => {
@@ -30,7 +31,7 @@ const TextSearch: FC<TextSearchProps> = ({ onChange, value }) => {
     return (
         <StyledInput
             id="keyword"
-            type="text"
+            type={type}
             onBlur={handleOnBlur}
             onKeyPress={handleKeyPress}
             onChange={(e) => {

--- a/src/Filter/modules/TextFilter/__tests__/textFilter.test.js
+++ b/src/Filter/modules/TextFilter/__tests__/textFilter.test.js
@@ -109,19 +109,30 @@ describe('TextFilter', () => {
         });
     });
 
-    describe('renderComponent', () => {
-        const { renderComponent } = TextFilter('', '');
-
+    describe('renderComponent', () => {    
         it('returns the expected component', () => {
+            const { renderComponent } = TextFilter('', '');
+            
             const update = jest.fn();
             const { getByRole } = render(<div>{renderComponent({ name: 'name', value: '1', update })}</div>);
             expect(getByRole('textbox')).toHaveValue('1');
             fireEvent.blur(getByRole('textbox'), { target: { value: 'asdf' } });
             expect(update).toBeCalledWith('asdf');
         });
+        
+        it('limits input to numbers only when specified', () => {
+            const { renderComponent } = TextFilter('', '', {}, { type: 'number' });
+
+            const update = jest.fn();
+            const { getByRole } = render(<div>{renderComponent({ name: 'name', value: '1', update })}</div>);
+            expect(getByRole('spinbutton')).toHaveValue(1);
+            fireEvent.blur(getByRole('spinbutton'), { target: { value: 'asdf' } });
+            expect(update).toBeCalledWith('');
+            expect(getByRole('spinbutton')).toHaveValue(null);
+        });
     });
 
-    describe('textFilterOptions', () => {
+    describe('textFilterOverrides', () => {
         const filterModuleKeys = [
             'label',
             'description',

--- a/src/Filter/modules/TextFilter/__tests__/textSearch.test.js
+++ b/src/Filter/modules/TextFilter/__tests__/textSearch.test.js
@@ -29,4 +29,13 @@ describe('<TextSearch />', () => {
         fireEvent.keyPress(getByRole('textbox'), { key: 'Enter', charCode: 13, target: { value: 'asdf' } });
         expect(changeCallback).toBeCalledWith('asdf');
     });
+
+    it('only accepts numbers when specified', () => {
+        const changeCallback = jest.fn();
+        const { getByRole } = render(<TextSearch onChange={changeCallback} type='number' />);
+        fireEvent.keyPress(getByRole('spinbutton'), { key: 'Enter', charCode: 13, target: { value: 'asdf' } });
+        expect(changeCallback).toBeCalledWith('');
+        fireEvent.keyPress(getByRole('spinbutton'), { key: 'Enter', charCode: 13, target: { value: '1' } });
+        expect(changeCallback).toBeCalledWith('1');
+    });
 });

--- a/src/Filter/types/index.ts
+++ b/src/Filter/types/index.ts
@@ -461,7 +461,7 @@ export interface RadioFilterProps {
  export interface SingleSelectFilterOptions extends Omit<Partial<FilterModule<string>>, 'description' | 'label' | 'required'> {}
 
 /**
- * `TextFilterOptions` is any valid `FilterModule` property (excluding description and label)
+ * `TextFilterOverrides` is any valid `FilterModule` property (excluding description and label)
  * meant to override default text filter behaviour.
  */
- export interface TextFilterOptions extends Omit<Partial<FilterModule<string>>, 'description' | 'label'> {}
+ export interface TextFilterOverrides extends Omit<Partial<FilterModule<string>>, 'description' | 'label'> {}

--- a/src/stories/Filter/TextFilter/TextFilter.stories.tsx
+++ b/src/stories/Filter/TextFilter/TextFilter.stories.tsx
@@ -17,9 +17,8 @@ export default {
             control: 'text',
             description: 'The description/help text to display above the text filter component.'
         },
-        textFilterOptions: {
-            control: false,
-            description: 'Any valid `FilterModule` property (excluding description and label) which will override default text filter behaviour.'
+        textFilterOverrides: {
+            control: false
         }
     },
     parameters: {
@@ -35,7 +34,13 @@ export default {
 // Text Filter
 const TextFilterTemplate: Story = (args: TextFilterArgs) => {
     const pageFilters = {
-        textFilter: TextFilterFunction(args.label, args.description, {})
+        textFilter: TextFilterFunction(args.label, args.description, {}),
+        numberFilter: TextFilterFunction(
+            'Number Filter',
+            'TextFilter input can be limited to accept numbers only.',
+            {},
+            { type: 'number' }
+        )
     };
 
     return <FilterPage pageFilters={pageFilters} />;

--- a/src/stories/Filter/TextFilter/TextFilterDocs.tsx
+++ b/src/stories/Filter/TextFilter/TextFilterDocs.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
-import { TextFilterOptions } from 'src/Filter/types';
+import { TextFilterOverrides } from 'src/Filter/types';
+import { TextFilterOptions } from 'src/Filter/modules/TextFilter/TextFilter';
 import { createFilterSourceCode } from 'src/stories/Filter/filterStoriesUtil';
 
 export interface TextFilterArgs {
@@ -15,7 +16,11 @@ export interface TextFilterArgs {
      * Any valid `FilterModule` property (excluding description and label)
      * which will override default text filter behaviour.
      */
-    textFilterOptions?: TextFilterOptions;
+     textFilterOverrides?: TextFilterOverrides;
+    /**
+     * Additional options for the text filter settings.
+     */
+    textFilterOptions: TextFilterOptions;
 }
 
 /**
@@ -27,8 +32,11 @@ export interface TextFilterArgs {
         'TextFilter is a text input control meant to be used as a keyword(s) search. (Tab or Enter to apply)',
         {
             getDefaultFilterValue: () => '',
-            ...additionalTextFilterOptions
-        }
+            ...additionalTextFilterOverrides
+        },
+        {
+            type: 'text'
+        },
     )
 }`);
 
@@ -37,7 +45,7 @@ export interface TextFilterArgs {
  * 
  * The TextFilter component is a text input control meant to be used as a keyword(s) search. While the default
  * behaviour should suffice, any valid `FilterModule` property (excluding description and label) can
- * be supplied via the `textFilterOptions` parameter to change how the filter looks and acts.
+ * be supplied via the `textFilterOverrides` parameter to change how the filter looks and acts.
  */
 const TextFilterDocs: FC<TextFilterArgs> = () => null;
 


### PR DESCRIPTION
This PR is for adding support to limit text filter input to numbers only. If approved it will close #172.

**Note: `TextFilterOptions` was renamed `TextFilterOverrides` to mimic `ListFilterOverrides` in the `ListFilter` module. With that said, the argument order was left unchanged to avoid breaking current usage of the module.

![Screen Shot 2021-10-04 at 2 13 57 PM](https://user-images.githubusercontent.com/80778550/135908455-b14064f3-0c48-4e21-a5ad-0077898510c8.png)
