### PR TITLE
Update Deploy GH Pages Workflow

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2.3.1
       - name: Install and Build
         run: | # Install npm packages and build the Storybook files
-          npm install
+          npm ci
           npm run build-storybook
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.94.6",
+  "version": "0.94.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.94.6",
+  "version": "0.94.7",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/Filter/modules/DurationFilter/DurationFilter.tsx
+++ b/src/Filter/modules/DurationFilter/DurationFilter.tsx
@@ -7,6 +7,7 @@ export interface DurationFilterProps {
     description?: string;
 }
 
+
 export const DurationFilter = ({ label, description }: DurationFilterProps): FilterModule<MinMax> => ({
     label,
     description,


### PR DESCRIPTION
This PR updates the Deploy GH Pages workflow to use npm ci instead of npm i to fix the workflow issue.