### PR TITLE
Maskable image bug fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.98.0",
+  "version": "0.98.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.98.0",
+      "version": "0.98.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.98.0",
+  "version": "0.98.1",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/CopyButton/CopyButton.tsx
+++ b/src/CopyButton/CopyButton.tsx
@@ -28,6 +28,11 @@ export interface CopyButtonProps {
      * The value to be copied to the clipboard.
      */
     valueToCopy: string;
+    /**
+     * This to set the iconOnly property. If set to false, the icon and text will appear. If true, only copy icon will render.
+     * By default, the IconOnly property is set to false.
+     */
+    iconOnly:boolean
 }
 
 /**
@@ -44,6 +49,7 @@ const CopyButton: FC<CopyButtonProps & Omit<ButtonComponentProps, 'onCopy'>> = (
     onCopy,
     valueToCopy,
     icon,
+    iconOnly=false,
     ...props
 }) => {
     return (
@@ -64,9 +70,10 @@ const CopyButton: FC<CopyButtonProps & Omit<ButtonComponentProps, 'onCopy'>> = (
             {...props}
             icon={icon || <FileCopy aria-label="File Copy" />}
         >
-            <CopyButtonContent hasContent={Boolean(children || buttonText)} className="copyButtonContent">
+            {!iconOnly && <CopyButtonContent hasContent={Boolean(children || buttonText)} className="copyButtonContent">
                 {children || buttonText}
             </CopyButtonContent>
+            }
         </Button>
     );
 };

--- a/src/CopyButton/__tests__/CopyButton.test.js
+++ b/src/CopyButton/__tests__/CopyButton.test.js
@@ -62,4 +62,11 @@ describe('CopyButton', () => {
 
         expect(onCopy).not.toHaveBeenCalled();;
     });
+
+    it('renders Icon Only', () => {
+        const onCopy = jest.fn();
+        const { getByText } = render(<CopyButton onCopy={onCopy} valueToCopy={COPY_TEXT} disabled iconOnly={true}/>);
+        // throws error as the text doesn't exist in iconOnly mode.
+        expect(()=>getByText(COPY_TEXT)).toThrowError();
+    });
 });

--- a/src/stories/MaskableImage/MaskableImage.stories.tsx
+++ b/src/stories/MaskableImage/MaskableImage.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, Story } from '@storybook/react/types-6-0';
 import MaskableImageComponent, { MaskableImageProps } from 'src/MaskableImage'
 import DocBlock from '.storybook/DocBlock';
 import { emerald } from 'src/styles/lakefrontColors';
+import imageFile from './__assets__/Nature.jpg';
 
 export default {
     title: 'Lakefront/MaskableImage',
@@ -42,7 +43,7 @@ const Template: Story<MaskableImageProps & ComponentPropsWithoutRef<'div'>> = (a
 
 export const MaskableImage = Template.bind({});
 MaskableImage.args = {
-    url: 'https://raw.githubusercontent.com/ToyotaResearchInstitute/lakefront/Maskable-Component/src/stories/MaskableImage/__assets__/Nature.jpg',
+    url: imageFile,
     fullSizeDimensions: { height: '1px', width: '2px' },
     selectable: true,
     selected: false,


### PR DESCRIPTION
This PR will fix the maskable image link which is not working right now.
<img width="1134" alt="Screen Shot 2022-02-07 at 3 36 19 PM" src="https://user-images.githubusercontent.com/30271951/152867730-1ba0cd31-f700-40fb-92a7-428512675bfd.png">
