### PR TITLE
Drive 73463 Make Lakefront Tables sortable on multiple columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.106.1",
+  "version": "0.106.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.106.1",
+      "version": "0.106.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.106.1",
+  "version": "0.106.2",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useTable, useSortBy, useExpanded, TableState, Column } from 'react-table';
+import { useTable, useSortBy, useExpanded, TableState, Column, TableSortByToggleProps } from 'react-table';
 import { StyledArrowDown, StyledArrowUp, StyledHeader, StyledHeaderContent, StyledUnsorted, TableStyle } from './tableStyles';
 import { ThemeProvider } from '@emotion/react';
 import theme from 'src/styles/theme';
@@ -48,7 +48,7 @@ export interface TableProps {
      * The first argument is the sorted column and the second argument is the sortBy array
      * (for if table is sorted by multiple columns).
      */
-    onChangeSort?({ id, desc }: SortByOptions, sortedBy?:SortByOptions[]): void;
+    onChangeSort?({ id, desc }: SortByOptions, sortedBy?: SortByOptions[]): void;
     /**
      * This is to set the row sub component on the table.
      */
@@ -93,7 +93,7 @@ const Table: React.FC<TableProps> = ({ className,
 
     useEffect(() => {
         if (onChangeSort && sortBy.length) {
-            onChangeSort( sortBy[0], sortBy );
+            onChangeSort(sortBy[0], sortBy);
         }
     }, [sortBy]);
 
@@ -105,19 +105,31 @@ const Table: React.FC<TableProps> = ({ className,
                     {headerGroups.map((headerGroup: any) => (
                         <tr {...headerGroup.getHeaderGroupProps()}>
                             {headerGroup.headers.map((column: any) => (
-                                    <th {
-                                        ...column.getHeaderProps( column.getSortByToggleProps(
-                                            { title: 'Hold shift & click the column to add to multi-sort', width:column.width },
-                                            ))
-                                        }>
-                                        <StyledHeader>
-                                            <StyledHeaderContent>{column.render('Header')}</StyledHeaderContent>
-                                            <StyledHeaderContent >
-                                                {column.isSorted ? <>{(column.isSortedDesc ? <StyledArrowDown className='sort-icon' /> : <StyledArrowUp className='sort-icon'/>)}</> : <StyledUnsorted className='sort-icon'/>}
-                                            </StyledHeaderContent>
-                                        </StyledHeader>
-                                    </th>
-                                )
+                                <th {
+                                    ...column.getHeaderProps(column.getSortByToggleProps(
+                                        (props: TableSortByToggleProps) => ({
+                                            ...props,
+                                            title: tableHookOptions.disableMultiSort ? 
+                                                props.title :
+                                                'Hold shift & click the column to add to multi-sort',
+                                            width: column.width
+                                        })
+                                    ))
+                                }>
+                                    <StyledHeader>
+                                        <StyledHeaderContent>{column.render('Header')}</StyledHeaderContent>
+                                        <StyledHeaderContent >
+                                            {column.isSorted ? 
+                                                <>
+                                                    {(column.isSortedDesc ? 
+                                                    <StyledArrowDown className='sort-icon' /> : 
+                                                    <StyledArrowUp className='sort-icon' />)}
+                                                </> : 
+                                                    <StyledUnsorted className='sort-icon' />}
+                                        </StyledHeaderContent>
+                                    </StyledHeader>
+                                </th>
+                            )
                             )}
                         </tr>
                     ))}

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect } from 'react';
 import { useTable, useSortBy, useExpanded, TableState, Column } from 'react-table';
-import { ReactComponent as ArrowUp } from './assets/arrow_drop_up.svg';
-import { ReactComponent as ArrowDown } from './assets/arrow_drop_down.svg';
-import { TableStyle } from './tableStyles';
+import { StyledArrowDown, StyledArrowUp, StyledHeader, StyledUnsorted, TableStyle } from './tableStyles';
 import { ThemeProvider } from '@emotion/react';
 import theme from 'src/styles/theme';
 
@@ -105,11 +103,17 @@ const Table: React.FC<TableProps> = ({ className,
                     {headerGroups.map((headerGroup: any) => (
                         <tr {...headerGroup.getHeaderGroupProps()}>
                             {headerGroup.headers.map((column: any) => (
-                                <th {...column.getHeaderProps(column.getSortByToggleProps())}>
-                                    {column.render('Header')}
-                                    {column.isSorted && (
-                                        <>{(column.isSortedDesc ? <ArrowDown /> : <ArrowUp />)}</>
-                                    )}
+                                <th {
+                                    ...column.getHeaderProps(column.getSortByToggleProps(
+                                        { title: 'Hold shift & click the column to add to multi-sort' }
+                                    ))
+                                    }>
+                                    <StyledHeader>
+                                        <div>{column.render('Header')}</div>
+                                        <div >
+                                            {column.isSorted ? <>{(column.isSortedDesc ? <StyledArrowDown /> : <StyledArrowUp />)}</> : <StyledUnsorted />}
+                                        </div>
+                                    </StyledHeader>
                                 </th>
                             ))}
                         </tr>

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useTable, useSortBy, useExpanded, TableState, Column } from 'react-table';
-import { StyledArrowDown, StyledArrowUp, StyledHeader, StyledUnsorted, TableStyle } from './tableStyles';
+import { StyledArrowDown, StyledArrowUp, StyledHeader, StyledHeaderContent, StyledUnsorted, TableStyle } from './tableStyles';
 import { ThemeProvider } from '@emotion/react';
 import theme from 'src/styles/theme';
 
@@ -45,8 +45,10 @@ export interface TableProps {
     initialSortBy?: { id: string; desc: boolean };
     /**
      * This event is triggered when the sorting is changed on the table.
+     * The first argument is the sorted column and the second argument is the sortBy array
+     * (for if table is sorted by multiple columns).
      */
-    onChangeSort?({ id, desc }: { id: string, desc: boolean }): void;
+    onChangeSort?({ id, desc }: SortByOptions, sortedBy?:SortByOptions[]): void;
     /**
      * This is to set the row sub component on the table.
      */
@@ -91,7 +93,7 @@ const Table: React.FC<TableProps> = ({ className,
 
     useEffect(() => {
         if (onChangeSort && sortBy.length) {
-            onChangeSort(sortBy[0]);
+            onChangeSort( sortBy[0], sortBy );
         }
     }, [sortBy]);
 
@@ -103,19 +105,20 @@ const Table: React.FC<TableProps> = ({ className,
                     {headerGroups.map((headerGroup: any) => (
                         <tr {...headerGroup.getHeaderGroupProps()}>
                             {headerGroup.headers.map((column: any) => (
-                                <th {
-                                    ...column.getHeaderProps(column.getSortByToggleProps(
-                                        { title: 'Hold shift & click the column to add to multi-sort' }
-                                    ))
-                                    }>
-                                    <StyledHeader>
-                                        <div>{column.render('Header')}</div>
-                                        <div >
-                                            {column.isSorted ? <>{(column.isSortedDesc ? <StyledArrowDown /> : <StyledArrowUp />)}</> : <StyledUnsorted />}
-                                        </div>
-                                    </StyledHeader>
-                                </th>
-                            ))}
+                                    <th {
+                                        ...column.getHeaderProps( column.getSortByToggleProps(
+                                            { title: 'Hold shift & click the column to add to multi-sort', width:column.width },
+                                            ))
+                                        }>
+                                        <StyledHeader>
+                                            <StyledHeaderContent>{column.render('Header')}</StyledHeaderContent>
+                                            <StyledHeaderContent >
+                                                {column.isSorted ? <>{(column.isSortedDesc ? <StyledArrowDown className='sort-icon' /> : <StyledArrowUp className='sort-icon'/>)}</> : <StyledUnsorted className='sort-icon'/>}
+                                            </StyledHeaderContent>
+                                        </StyledHeader>
+                                    </th>
+                                )
+                            )}
                         </tr>
                     ))}
                 </thead>

--- a/src/Table/__tests__/Table.test.jsx
+++ b/src/Table/__tests__/Table.test.jsx
@@ -1,5 +1,4 @@
 import { render, fireEvent, cleanup } from '@testing-library/react';
-
 import Table from '../Table';
 
 afterAll(cleanup);
@@ -8,6 +7,7 @@ const columns = [
     {
         Header: 'TITLE',
         accessor: 'title',
+        width: 100,
         Cell: ({ cell: { value } }) => value
     },
     {
@@ -30,33 +30,46 @@ const columns = [
     }
 ];
 const customData = [{ title: 'r2204_1_0', value: 24, percentage: 166.992, percentage_change: 6.9579999999, total: 0.14371985 },
-{ title: 'r2002_1_0', value: 3, percentage: 47.442, percentage_change: 15.814, total: 0.063491 },
+{ title: 'r2012_1_0', value: 3, percentage: 47.442, percentage_change: 15.814, total: 0.063491 },
 { title: 'r2010_1_0', value: 5, percentage: 25.68, percentage_change: 5.136, total: 0.1947675 },
-{ title: 'r2019_1_0', value: 51, percentage: 291.549, percentage_change: 5.7166473529, total: 0.1749277202 }]
+{ title: 'r2019_1_0', value: 51, percentage: 291.549, percentage_change: 5.7166473529, total: 0.1949277202 },
+{ title: 'r2020_1_0', value: 31, percentage: 271.549, percentage_change: 5.7166473529, total: 0.1749277202 },
+{ title: 'r2021_1_0', value: 41, percentage: 281.549, percentage_change: 5.7166473529, total: 0.1849277202 }]
 
 describe('<Table>', () => {
     it('check if table renders properly', () => {
         const { container } = render(<Table columns={columns} data={customData} />);
 
-        expect(container.querySelectorAll('tbody tr').length).toBe(4);
+        expect(container.querySelectorAll('tbody tr').length).toBe(6);
         expect(container.querySelector('table')).toHaveStyle("width: 100%;");
     });
 
     it('checks if the column sorting is working', () => {
-        const { container } = render(<Table columns={columns} data={customData}
-            initialSortBy={{ id: 'title', desc: false }} />);
+        const mockHandleSort = jest.fn()
+        const { container, getAllByRole } = render(<Table columns={columns} data={customData}
+            initialSortBy={{ id: 'title', desc: false }} onChangeSort={mockHandleSort} />);
 
         // initial sorting applied on release column
-        const releaseCol = container.querySelectorAll('thead th')[0];
-        expect(releaseCol.innerHTML).toBe("TITLE<svg></svg>");
+        expect(getAllByRole('cell')[0].textContent).toBe('r2010_1_0')
 
-        // sorting is not applied on count column
-        const countCol = container.querySelectorAll('thead th')[1];
-        expect(countCol.innerHTML).not.toBe("VALUE<svg></svg>");
+        // sorting is not applied on percentage column
+        const percentageChange = container.querySelectorAll('thead th')[3];
+        expect(getAllByRole('cell')[3].textContent).toBe('5.1360')
+        expect(getAllByRole('cell')[8].textContent).toBe('15.8140')
+        expect(getAllByRole('cell')[13].textContent).toBe('5.7166')
+        expect(getAllByRole('cell')[18].textContent).toBe('5.7166')
+        expect(getAllByRole('cell')[23].textContent).toBe('5.7166')
+        expect(getAllByRole('cell')[28].textContent).toBe('6.9580')
 
-        // sorting is applied on count column on click event
-        fireEvent.click(countCol);
-        expect(countCol.innerHTML).toBe("VALUE<svg></svg>");
+        // sorting is applied on percentage change column on click event
+        fireEvent.click(percentageChange);
+        expect(getAllByRole('cell')[3].textContent).toBe('5.1360')
+        expect(getAllByRole('cell')[8].textContent).toBe('5.7166')
+        expect(getAllByRole('cell')[13].textContent).toBe('5.7166')
+        expect(getAllByRole('cell')[18].textContent).toBe('5.7166')
+        expect(getAllByRole('cell')[23].textContent).toBe('6.9580')
+        expect(getAllByRole('cell')[28].textContent).toBe('15.8140')
+
     });
 
     it('check if message is displayed properly when data is not present', () => {
@@ -64,5 +77,36 @@ describe('<Table>', () => {
 
         expect(container.innerHTML).toContain('No data found');
 
+    });
+
+    it('check if the tooltip on the header indicates that multiple sort criteria is possible by shift-clicking to add to the sort.', () => {
+        const { container } = render(<Table columns={columns} data={customData}
+        initialSortBy={{ id: 'title', desc: false }} />);
+
+        expect(container.querySelectorAll('th')[0].title).toBe('Hold shift & click the column to add to multi-sort')
+        expect(container.querySelectorAll('th')[1].title).toBe('Hold shift & click the column to add to multi-sort')
+        expect(container.querySelectorAll('th')[2].title).toBe('Hold shift & click the column to add to multi-sort')
+        expect(container.querySelectorAll('th')[3].title).toBe('Hold shift & click the column to add to multi-sort')
+        expect(container.querySelectorAll('th')[4].title).toBe('Hold shift & click the column to add to multi-sort')
+
+    });
+
+    it('renders Title column with a width of 100px & all other columns with 150px', () => {
+        const { getAllByRole } = render(<Table columns={columns} data={customData}
+            initialSortBy={{ id: 'title', desc: false }} />);
+
+            expect(getAllByRole('columnheader')[0].width).toBe('100');
+            expect(getAllByRole('columnheader')[1].width).toBe('150');
+            expect(getAllByRole('columnheader')[2].width).toBe('150');
+            expect(getAllByRole('columnheader')[3].width).toBe('150');
+            expect(getAllByRole('columnheader')[4].width).toBe('150');
+    });
+
+    it('calls the mockHandleSort function', () => {
+        const mockHandleSort = jest.fn()
+        render(<Table columns={columns} data={customData} 
+            initialSortBy={{ id: 'title', desc: false }} onChangeSort={mockHandleSort}/>);
+
+            expect(mockHandleSort).toHaveBeenCalledWith({"desc": false, "id": "title"}, [{"desc": false, "id": "title"}]);
     });
 });

--- a/src/Table/assets/unsorted.svg
+++ b/src/Table/assets/unsorted.svg
@@ -1,0 +1,4 @@
+<svg width="10" height="12">
+    <path d="M0 5 H10 L 5 0 Z" />
+    <path d="M0 7 H10 L 5 12 Z" />
+</svg>

--- a/src/Table/tableStyles.ts
+++ b/src/Table/tableStyles.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { colors } from 'src';
+import colors from 'src/styles/lakefrontColors';
 import { ReactComponent as ArrowUp } from './assets/arrow_drop_up.svg';
 import { ReactComponent as ArrowDown } from './assets/arrow_drop_down.svg';
 import { ReactComponent as Unsorted } from './assets/unsorted.svg'
@@ -52,7 +52,20 @@ export const StyledHeader = styled.div({
     display:'flex', 
     alignItems:'center', 
     justifyContent:'flex-start',
-    width:'fit-Content'
+    'div:first-of-type':{
+        width: 'max-content'
+    }
+});
+
+export const StyledHeaderContent = styled.div({
+    display:'flex', 
+    alignItems:'center', 
+    justifyContent:'flex-start',
+    'svg.sort-icon':{
+        marginTop: 0,
+        position: 'static',    
+        fill: colors.pavement,        
+    }
 });
 
 export const StyledArrowDown = styled(ArrowDown)({
@@ -66,8 +79,7 @@ export const StyledArrowUp = styled(ArrowUp)({
 })
 
 export const StyledUnsorted = styled(Unsorted)({
-    paddingLeft:5,
-    paddingTop:8,
+    marginLeft:8,
     position:'relative',
     top:10
 })

--- a/src/Table/tableStyles.ts
+++ b/src/Table/tableStyles.ts
@@ -42,26 +42,26 @@ export const TableStyle = styled.table(({ theme }) => ({
         '&.marginBottom': {
             marginBottom: 5
         },
-        svg:{
+        svg: {
             fill: colors.pavement,          
         }
     }
 }));
 
 export const StyledHeader = styled.div({
-    display:'flex', 
-    alignItems:'center', 
-    justifyContent:'flex-start',
+    display: 'flex', 
+    alignItems: 'center', 
+    justifyContent: 'flex-start',
     'div:first-of-type':{
         width: 'max-content'
     }
 });
 
 export const StyledHeaderContent = styled.div({
-    display:'flex', 
-    alignItems:'center', 
-    justifyContent:'flex-start',
-    'svg.sort-icon':{
+    display: 'flex', 
+    alignItems: 'center', 
+    justifyContent: 'flex-start',
+    'svg.sort-icon': {
         marginTop: 0,
         position: 'static',    
         fill: colors.pavement,        
@@ -69,17 +69,17 @@ export const StyledHeaderContent = styled.div({
 });
 
 export const StyledArrowDown = styled(ArrowDown)({
-    paddingLeft:5,
-    paddingTop:3
+    paddingLeft: 5,
+    paddingTop: 3
 })
 
 export const StyledArrowUp = styled(ArrowUp)({
-    paddingLeft:5,
-    paddingTop:3
+    paddingLeft: 5,
+    paddingTop: 3
 })
 
 export const StyledUnsorted = styled(Unsorted)({
-    marginLeft:8,
-    position:'relative',
-    top:10
+    marginLeft: 8,
+    position: 'relative',
+    top: 10
 })

--- a/src/Table/tableStyles.ts
+++ b/src/Table/tableStyles.ts
@@ -1,4 +1,8 @@
 import styled from '@emotion/styled';
+import { colors } from 'src';
+import { ReactComponent as ArrowUp } from './assets/arrow_drop_up.svg';
+import { ReactComponent as ArrowDown } from './assets/arrow_drop_down.svg';
+import { ReactComponent as Unsorted } from './assets/unsorted.svg'
 
 export const TableStyle = styled.table(({ theme }) => ({
     padding: 0,
@@ -20,7 +24,8 @@ export const TableStyle = styled.table(({ theme }) => ({
         'svg': {
             marginTop: 2,
             position: 'absolute',
-            top: 6
+            top: 6,
+            fill: colors.pavement,
         }
     },
     'th,td': {
@@ -36,6 +41,33 @@ export const TableStyle = styled.table(({ theme }) => ({
 
         '&.marginBottom': {
             marginBottom: 5
+        },
+        svg:{
+            fill: colors.pavement,          
         }
     }
 }));
+
+export const StyledHeader = styled.div({
+    display:'flex', 
+    alignItems:'center', 
+    justifyContent:'flex-start',
+    width:'fit-Content'
+});
+
+export const StyledArrowDown = styled(ArrowDown)({
+    paddingLeft:5,
+    paddingTop:3
+})
+
+export const StyledArrowUp = styled(ArrowUp)({
+    paddingLeft:5,
+    paddingTop:3
+})
+
+export const StyledUnsorted = styled(Unsorted)({
+    paddingLeft:5,
+    paddingTop:8,
+    position:'relative',
+    top:10
+})

--- a/src/stories/Table/Table.stories.tsx
+++ b/src/stories/Table/Table.stories.tsx
@@ -1,4 +1,3 @@
-
 import { ComponentPropsWithoutRef, useState } from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import Button from 'src/Button/Button';
@@ -64,10 +63,15 @@ const Template: Story<TableProps & ComponentPropsWithoutRef<'div'>> = (args) => 
         setDataToggle(dataToggle => !dataToggle);
     }
 
-    const handleSort = ({ id, desc }) => {
-        const newMsg = 'Sorting is applied on column name: ' + columns.filter(col => col.accessor === id)[0].Header;
-        const sortOrder = desc ? ' (Descending Order)' : ' (Ascending Order)';
-        setSortMsg(newMsg + sortOrder);
+    const handleSort = (_, sortedBy) => {
+        const newMsg = 'Sorting is applied on column name(s): ' ;
+        const columnNamesAndSortDirection = sortedBy.map((sortedColumn) => {
+            const colName = columns.find(col => col.accessor === sortedColumn.id).Header 
+             const sortDirection = sortedColumn.desc ? '(Descending Order)' : '(Ascending Order)';
+             return ` ${colName} ${sortDirection}`
+        })
+
+        setSortMsg(`${newMsg} ${columnNamesAndSortDirection}`);
     };
 
     return (

--- a/src/stories/Table/Table.stories.tsx
+++ b/src/stories/Table/Table.stories.tsx
@@ -40,6 +40,37 @@ const columns = [
     }
 ];
 
+const columnsWithWidth = [
+    {
+        Header: 'TITLE',
+        accessor: 'title',
+        width:100,
+        Cell: ({ cell: { value } }) => value
+    },
+    {
+        Header: 'VALUE',
+        accessor: 'value',
+        width:100
+    },
+    {
+        Header: 'PERCENTAGE',
+        accessor: 'percentage',
+        width:100
+    },
+    {
+        Header: 'PERCENTAGE CHANGE',
+        accessor: 'percentage_change',
+        width:140,
+        Cell: ({ cell: { value } }) => value?.toFixed(4) || ''
+    },
+    {
+        Header: 'TOTAL/100',
+        accessor: 'total',
+        width:50,
+        Cell: ({ cell: { value } }) => value?.toFixed(4) || ''
+    }
+];
+
 const customData = [{ title: 'r2204_1_0', value: 24, percentage: 166.992, percentage_change: 6.9579999999, total: 0.14371985 },
 { title: 'r2002_1_0', value: 3, percentage: 47.442, percentage_change: 15.814, total: 0.063491 },
 { title: 'r2010_1_0', value: 5, percentage: 25.68, percentage_change: 5.136, total: 0.1947675 },
@@ -97,6 +128,28 @@ Table.args = {
     options: {
         disableSortRemove: true,
         autoResetSortBy: true,
+        disableMultiSort: false
+    }
+};
+
+export const TableWithMultiSortDisabled = Template.bind({});
+TableWithMultiSortDisabled.args = {
+    columns: columns,
+    data: customData,
+    initialSortBy: { id: 'title', desc: false },
+    noDataMessage: "No data found",
+    options: {
+        disableMultiSort: true
+    }
+};
+
+export const TableWithCustomWidth = Template.bind({});
+TableWithCustomWidth.args = {
+    columns: columnsWithWidth,
+    data: customData,
+    initialSortBy: { id: 'title', desc: false },
+    noDataMessage: "No data found",
+    options: {
         disableMultiSort: false
     }
 };

--- a/src/stories/Table/Table.stories.tsx
+++ b/src/stories/Table/Table.stories.tsx
@@ -44,13 +44,13 @@ const columns = [
 const customData = [{ title: 'r2204_1_0', value: 24, percentage: 166.992, percentage_change: 6.9579999999, total: 0.14371985 },
 { title: 'r2002_1_0', value: 3, percentage: 47.442, percentage_change: 15.814, total: 0.063491 },
 { title: 'r2010_1_0', value: 5, percentage: 25.68, percentage_change: 5.136, total: 0.1947675 },
-{ title: 'r2019_1_0', value: 51, percentage: 291.549, percentage_change: 5.7166473529, total: 0.1749277202 },
+{ title: 'r2019_1_0', value: 51, percentage: 291.549, percentage_change: 5.7166473529, total: 0.1959277202 },
 { title: 'r2125_1_0', value: 39, percentage: 175.199, percentage_change: 4.4922282052, total: 0.2226686241 },
 { title: 'r2018_1_0', value: 12, percentage: 80.672, percentage_change: 6.7266666, total: 0.148750612 },
 { title: 'r2027_1_0', value: 83, percentage: 275.087, percentage_change: 3.314819277, total: 0.3017716 },
 { title: 'r2016_1_0', value: 27, percentage: 130.419, percentage_change: 4.830333334, total: 0.20705373 },
-{ title: 'r2115_1_0', value: 18, percentage: 97.505, percentage_change: 5.41694444, total: 0.1846059897 },
-{ title: 'r1112_1_0', value: 22, percentage: 113.747, percentage_change: 5.17018182, total: 0.193415712 },
+{ title: 'r2115_1_0', value: 18, percentage: 97.505, percentage_change: 5.7166473529, total: 0.1746059897 },
+{ title: 'r1112_1_0', value: 22, percentage: 113.747, percentage_change: 5.7166473529, total: 0.193415712 },
 { title: 'r2110_1_0', value: 80, percentage: 304.77, percentage_change: 3.80969996, total: 0.2625626 }];
 
 const Template: Story<TableProps & ComponentPropsWithoutRef<'div'>> = (args) => {
@@ -93,6 +93,6 @@ Table.args = {
     options: {
         disableSortRemove: true,
         autoResetSortBy: true,
-        disableMultiSort: true
+        disableMultiSort: false
     }
 };


### PR DESCRIPTION
Description:
Updated [Lakefront table](https://toyotaresearchinstitute.github.io/lakefront/?path=%2Fdocs%2Flakefront-table--table) to support:

The table allows sorting by multiple columns (ascending and descending).
The table accepts a parameter setting the default sort.
Users can apply multiple sort criteria by shift-clicking on the columns.
A tooltip on the title indicates that multiple sort criteria are possible by shift-clicking to add to the sort.
Accepts width as a parameter.