### PR TITLE
Add-easier-multi-sort-to-table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.110.5",
+  "version": "0.110.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.110.5",
+      "version": "0.110.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.111.3",
+  "version": "0.111.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.111.3",
+      "version": "0.111.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.111.2",
+  "version": "0.111.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.111.2",
+      "version": "0.111.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.111.2",
+  "version": "0.111.3",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.111.3",
+  "version": "0.111.4",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.110.5",
+  "version": "0.110.6",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -42,7 +42,7 @@ export interface TableProps {
     className?: string;
     /**
     * This is to set the initial sorting on the table.
-    * The first id provided will take precedence of other ids in array when sorted. Example: value --> title --> percentage.
+    * When an array of items is provided, the order dictates the priority of sorting. Example: value --> title --> percentage.
     */
     initialSortBy?: { id: string, desc: boolean}[] | { id: string, desc: boolean};
     

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useTable, useSortBy, useExpanded, TableState, Column, TableSortByToggleProps } from 'react-table';
 import { StyledHeader, StyledHeaderContent, TableStyle } from './tableStyles';
 import { ThemeProvider } from '@emotion/react';
@@ -42,8 +42,10 @@ export interface TableProps {
     className?: string;
     /**
     * This is to set the initial sorting on the table.
+    * The first id provided will take precedence of other ids in array when sorted. Example: value --> title --> percentage.
     */
-    initialSortBy?: { id: string; desc: boolean };
+    initialSortBy?: { id: string, desc: boolean}[] | { id: string, desc: boolean};
+    
     /**
      * This event is triggered when the sorting is changed on the table.
      * The first argument is the sorted column and the second argument is the sortBy array
@@ -74,81 +76,91 @@ const Table: React.FC<TableProps> = ({ className,
     initialSortBy,
     rowProps,
     renderRowSubComponent }) => {
+        /** initalSortBy must be memoized
+         * https://react-table-v7.tanstack.com/docs/api/useSortBy#table-options
+         */
+        const initialSortByData = useMemo(
+            () =>
+                initialSortBy
+                    ? { initialState: { sortBy: Array.isArray(initialSortBy) ? initialSortBy : [initialSortBy] } }
+                    : {},
+            [initialSortBy]
+        );
 
-    // Use the state and functions returned from useTable to build your UI
-    const tableHookOptions = {
-        ...options,
-        columns,
-        data,
-        ...(initialSortBy && { initialState: { sortBy: [initialSortBy] } })
-    };
-    const { getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
-        state,
-        ...rest
-    } = useTable(tableHookOptions, useSortBy, useExpanded);
-    const { sortBy } = state as CustomTableOptions;
+        // Use the state and functions returned from useTable to build your UI
+        const tableHookOptions = {
+            ...options,
+            columns,
+            data,
+            ...initialSortByData
+        };
+        const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow, state, ...rest } = useTable(
+            tableHookOptions,
+            useSortBy,
+            useExpanded
+        );
 
-    useEffect(() => {
-        if (onChangeSort && sortBy.length) {
-            onChangeSort(sortBy[0], sortBy);
-        }
-    }, [sortBy]);
+        const { sortBy } = state as CustomTableOptions;
 
-    // Render the UI for your table
-    return (
-        <ThemeProvider theme={theme}>
-            <TableStyle {...getTableProps()} className={className} style={style}>
-                <thead>
-                    {headerGroups.map((headerGroup: any) => (
-                        <tr {...headerGroup.getHeaderGroupProps()}>
-                            {headerGroup.headers.map((column: any) => (
-                                <th {
-                                    ...column.getHeaderProps(column.getSortByToggleProps
-                                        (
-                                            (props: TableSortByToggleProps) =>
-                                            ({
+        useEffect(() => {
+            if (onChangeSort && sortBy.length) {
+                onChangeSort(sortBy[0], sortBy);
+            }
+        }, [sortBy]);
+
+        // Render the UI for your table
+        return (
+            <ThemeProvider theme={theme}>
+                <TableStyle {...getTableProps()} className={className} style={style}>
+                    <thead>
+                        {headerGroups.map((headerGroup: any) => (
+                            <tr {...headerGroup.getHeaderGroupProps()}>
+                                {headerGroup.headers.map((column: any) => (
+                                    <th
+                                        {...column.getHeaderProps(
+                                            column.getSortByToggleProps((props: TableSortByToggleProps) => ({
                                                 ...props,
-                                                title: getTitleForMultiSort(tableHookOptions.disableMultiSort, props.title, column.disableSortBy),
+                                                title: getTitleForMultiSort(
+                                                    tableHookOptions.disableMultiSort,
+                                                    props.title,
+                                                    column.disableSortBy
+                                                ),
                                                 width: column.width
-                                            })
-                                        )
-                                    )
-                                }>
-                                    <StyledHeader>
-                                        <StyledHeaderContent>{column.render('Header')}</StyledHeaderContent>
-                                        <StyledHeaderContent >
-                                            {getSortBySVG(column)}
-                                        </StyledHeaderContent>
-                                    </StyledHeader>
-                                </th>
-                            )
-                            )}
-                        </tr>
-                    ))}
-                </thead>
-                <tbody {...getTableBodyProps()}>
-                    {rows.map((row: any) => {
-                        prepareRow(row);
-                        return (
-                            <React.Fragment key={row.id}>
-                                <tr {...row.getRowProps(rowProps)}>
-                                    {row.cells.map((cell: any) => {
-                                        return <td {...cell.getCellProps()}>{cell.render('Cell')}</td>;
-                                    })}
-                                </tr>
-                                {row.isExpanded && renderRowSubComponent ? (renderRowSubComponent({ row })) : null}
-                            </React.Fragment>
-                        );
-                    })}
-                    {rows.length === 0 && <tr><td colSpan={columns.length}>{noDataMessage}</td></tr>}
-                </tbody>
-            </TableStyle>
-        </ThemeProvider>
-    );
-};
+                                            }))
+                                        )}
+                                    >
+                                        <StyledHeader>
+                                            <StyledHeaderContent>{column.render('Header')}</StyledHeaderContent>
+                                            <StyledHeaderContent>{getSortBySVG(column)}</StyledHeaderContent>
+                                        </StyledHeader>
+                                    </th>
+                                ))}
+                            </tr>
+                        ))}
+                    </thead>
+                    <tbody {...getTableBodyProps()}>
+                        {rows.map((row: any) => {
+                            prepareRow(row);
+                            return (
+                                <React.Fragment key={row.id}>
+                                    <tr {...row.getRowProps(rowProps)}>
+                                        {row.cells.map((cell: any) => {
+                                            return <td {...cell.getCellProps()}>{cell.render('Cell')}</td>;
+                                        })}
+                                    </tr>
+                                    {row.isExpanded && renderRowSubComponent ? renderRowSubComponent({ row }) : null}
+                                </React.Fragment>
+                            );
+                        })}
+                        {rows.length === 0 && (
+                            <tr>
+                                <td colSpan={columns.length}>{noDataMessage}</td>
+                            </tr>
+                        )}
+                    </tbody>
+                </TableStyle>
+            </ThemeProvider>
+        );
+    };
 
 export default Table;

--- a/src/Table/__tests__/Table.test.jsx
+++ b/src/Table/__tests__/Table.test.jsx
@@ -34,41 +34,41 @@ const customData = [{ title: 'r2204_1_0', value: 24, percentage: 166.992, percen
 { title: 'r2010_1_0', value: 5, percentage: 25.68, percentage_change: 5.136, total: 0.1947675 },
 { title: 'r2019_1_0', value: 51, percentage: 291.549, percentage_change: 5.7166473529, total: 0.1949277202 },
 { title: 'r2020_1_0', value: 31, percentage: 271.549, percentage_change: 5.7166473529, total: 0.1749277202 },
-{ title: 'r2021_1_0', value: 41, percentage: 281.549, percentage_change: 5.7166473529, total: 0.1849277202 }]
+{ title: 'r2021_1_0', value: 41, percentage: 281.549, percentage_change: 5.7166473529, total: 0.1849277202 }];
 
 describe('<Table>', () => {
     it('check if table renders properly', () => {
         const { container } = render(<Table columns={columns} data={customData} />);
 
         expect(container.querySelectorAll('tbody tr').length).toBe(6);
-        expect(container.querySelector('table')).toHaveStyle("width: 100%;");
+        expect(container.querySelector('table')).toHaveStyle('width: 100%;');
     });
 
     it('checks if the column sorting is working', () => {
-        const mockHandleSort = jest.fn()
+        const mockHandleSort = jest.fn();
         const { container, getAllByRole } = render(<Table columns={columns} data={customData}
             initialSortBy={{ id: 'title', desc: false }} onChangeSort={mockHandleSort} />);
 
         // initial sorting applied on release column
-        expect(getAllByRole('cell')[0].textContent).toBe('r2010_1_0')
+        expect(getAllByRole('cell')[0].textContent).toBe('r2010_1_0');
 
         // sorting is not applied on percentage column
         const percentageChange = container.querySelectorAll('thead th')[3];
-        expect(getAllByRole('cell')[3].textContent).toBe('5.1360')
-        expect(getAllByRole('cell')[8].textContent).toBe('15.8140')
-        expect(getAllByRole('cell')[13].textContent).toBe('5.7166')
-        expect(getAllByRole('cell')[18].textContent).toBe('5.7166')
-        expect(getAllByRole('cell')[23].textContent).toBe('5.7166')
-        expect(getAllByRole('cell')[28].textContent).toBe('6.9580')
+        expect(getAllByRole('cell')[3].textContent).toBe('5.1360');
+        expect(getAllByRole('cell')[8].textContent).toBe('15.8140');
+        expect(getAllByRole('cell')[13].textContent).toBe('5.7166');
+        expect(getAllByRole('cell')[18].textContent).toBe('5.7166');
+        expect(getAllByRole('cell')[23].textContent).toBe('5.7166');
+        expect(getAllByRole('cell')[28].textContent).toBe('6.9580');
 
         // sorting is applied on percentage change column on click event
         fireEvent.click(percentageChange);
-        expect(getAllByRole('cell')[3].textContent).toBe('5.1360')
-        expect(getAllByRole('cell')[8].textContent).toBe('5.7166')
-        expect(getAllByRole('cell')[13].textContent).toBe('5.7166')
-        expect(getAllByRole('cell')[18].textContent).toBe('5.7166')
-        expect(getAllByRole('cell')[23].textContent).toBe('6.9580')
-        expect(getAllByRole('cell')[28].textContent).toBe('15.8140')
+        expect(getAllByRole('cell')[3].textContent).toBe('5.1360');
+        expect(getAllByRole('cell')[8].textContent).toBe('5.7166');
+        expect(getAllByRole('cell')[13].textContent).toBe('5.7166');
+        expect(getAllByRole('cell')[18].textContent).toBe('5.7166');
+        expect(getAllByRole('cell')[23].textContent).toBe('6.9580');
+        expect(getAllByRole('cell')[28].textContent).toBe('15.8140');
 
     });
 
@@ -83,11 +83,11 @@ describe('<Table>', () => {
         const { container } = render(<Table columns={columns} data={customData}
             initialSortBy={{ id: 'title', desc: false }} />);
 
-        expect(container.querySelectorAll('th')[0].title).toBe('Hold shift & click the column to add to multi-sort')
-        expect(container.querySelectorAll('th')[1].title).toBe('Hold shift & click the column to add to multi-sort')
-        expect(container.querySelectorAll('th')[2].title).toBe('Hold shift & click the column to add to multi-sort')
-        expect(container.querySelectorAll('th')[3].title).toBe('Hold shift & click the column to add to multi-sort')
-        expect(container.querySelectorAll('th')[4].title).toBe('Hold shift & click the column to add to multi-sort')
+        expect(container.querySelectorAll('th')[0].title).toBe('Hold shift & click the column to add to multi-sort');
+        expect(container.querySelectorAll('th')[1].title).toBe('Hold shift & click the column to add to multi-sort');
+        expect(container.querySelectorAll('th')[2].title).toBe('Hold shift & click the column to add to multi-sort');
+        expect(container.querySelectorAll('th')[3].title).toBe('Hold shift & click the column to add to multi-sort');
+        expect(container.querySelectorAll('th')[4].title).toBe('Hold shift & click the column to add to multi-sort');
 
     });
 
@@ -103,10 +103,18 @@ describe('<Table>', () => {
     });
 
     it('calls the mockHandleSort function', () => {
-        const mockHandleSort = jest.fn()
+        const mockHandleSort = jest.fn();
         render(<Table columns={columns} data={customData}
             initialSortBy={{ id: 'title', desc: false }} onChangeSort={mockHandleSort} />);
 
-        expect(mockHandleSort).toHaveBeenCalledWith({ "desc": false, "id": "title" }, [{ "desc": false, "id": "title" }]);
+        expect(mockHandleSort).toHaveBeenCalledWith({ 'desc': false, 'id': 'title' }, [{ 'desc': false, 'id': 'title' }]);
+    });
+
+    it('accepts array of initalSortBy data ', () => {
+        const mockHandleSort = jest.fn();
+        render(<Table columns={columns} data={customData}
+            initialSortBy={[{ id: 'value', desc: false }, { id: 'title', desc: true }, { id: 'percentage', desc: true }]} onChangeSort={mockHandleSort} />);
+
+        expect(mockHandleSort).toHaveBeenCalledWith( {'desc': false, 'id': 'value'}, [{'desc': false, 'id': 'value'}, {'desc': true, 'id': 'title'}, {'desc': true, 'id': 'percentage'}]);
     });
 });

--- a/src/Table/__tests__/tableUtil.test.tsx
+++ b/src/Table/__tests__/tableUtil.test.tsx
@@ -1,11 +1,11 @@
-import { render } from "@testing-library/react";
-import { getSortBySVG, getSortDirectionSVG, getTitleForColumn, getTitleForMultiSort, MULTI_SORT_TITLE } from "../tableUtil"
+import { render } from '@testing-library/react';
+import { getSortBySVG, getSortDirectionSVG, getTitleForColumn, getTitleForMultiSort, MULTI_SORT_TITLE } from '../tableUtil';
 
 const defaultColumn = {
     disableSortBy: true,
     isSorted: true,
     isSortedDesc: true
-}
+};
 
 describe('tableUtil', () => {
     describe('getSortBySVG', () => {
@@ -14,23 +14,22 @@ describe('tableUtil', () => {
             const result = getSortBySVG(defaultColumn);
 
             expect(result).toBeNull();
-        })
+        });
 
         it('returns the SVG when disableSortBy is falsy', () => {
 
             const { container } = render(<>{getSortBySVG({ ...defaultColumn, disableSortBy: false, isSorted: false })}</>);
 
             expect(container.querySelector('svg.sort-icon')).toBeInTheDocument();
-        })
+        });
 
         it('returns the unsorted svg when column isSorted is falsy', () => {
 
             const { container } = render(<>{getSortBySVG({ ...defaultColumn, disableSortBy: false, isSorted: false })}</>);
 
             expect(container.querySelector('svg[aria-label="unsorted-icon"]')).toBeInTheDocument();
-        })
-
-    })
+        });
+    });
 
     describe('getSortDirectionSVG', () => {
         it('returns the arrow-up svg when column is sorted in ascending order', () => {
@@ -38,38 +37,45 @@ describe('tableUtil', () => {
             const { container } = render(<>{getSortDirectionSVG(false)}</>);
 
             expect(container.querySelector('svg[aria-label="arrow-up"]')).toBeInTheDocument();
-        })
+        });
 
         it('returns arrow-down svg when column is sorted in descending order', () => {
 
             const { container } = render(<>{getSortDirectionSVG(true)}</>);
 
             expect(container.querySelector('svg[aria-label="arrow-down"]')).toBeInTheDocument();
-        })
-    })
+        });
+    });
 
     describe('getTitleForMultisort', () => {
         it('returns title as testTitle when multi-sort is disabled', () => {
 
             const result = getTitleForMultiSort(true, 'testTitle', false);
 
-            expect(result).toBe('testTitle')
-        })
-    })
+            expect(result).toBe('testTitle');
+        });
+
+        it('returns title as "" when title is not provided', () => {
+
+            const result = getTitleForMultiSort(true, undefined, false);
+
+            expect(result).toBe('');
+        });
+    });
 
     describe('getTitleForCloumn', () => {
         it('returns an empty string when sorting is disabled on a column', () => {
 
             const result = getTitleForColumn(true);
 
-            expect(result).toBe('')
-        })
+            expect(result).toBe('');
+        });
 
         it(`returns ${MULTI_SORT_TITLE} when sorting is enabled on a column`, () => {
 
             const result = getTitleForColumn(false);
 
             expect(result).toBe(MULTI_SORT_TITLE);
-        })
-    })
-})
+        });
+    });
+});

--- a/src/Table/tableUtil.tsx
+++ b/src/Table/tableUtil.tsx
@@ -8,23 +8,23 @@ export interface Column {
 
 export const getSortBySVG = ({ disableSortBy, isSorted, isSortedDesc }: Column) => {
     if (disableSortBy) {
-        return null
+        return null;
     }
 
     return (
         isSorted ? getSortDirectionSVG(isSortedDesc) : <StyledUnsorted aria-label='unsorted-icon' className='sort-icon' />
     );
-}
+};
 
 export const getSortDirectionSVG = (isSortedDesc: boolean) =>
     isSortedDesc ? <StyledArrowDown aria-label='arrow-down' className='sort-icon' /> : <StyledArrowUp aria-label='arrow-up' className='sort-icon' />;
 
 export const getTitleForMultiSort = (disableMultiSort: boolean, title: string = '', disableSortBy: boolean): string => {
     return disableMultiSort ? title : getTitleForColumn(disableSortBy);
-}
+};
 
 export const MULTI_SORT_TITLE = 'Hold shift & click the column to add to multi-sort';
 
 export const getTitleForColumn = (disableSortBy: boolean): string => {
     return disableSortBy ? '' : MULTI_SORT_TITLE;
-}
+};

--- a/src/stories/Table/Table.stories.tsx
+++ b/src/stories/Table/Table.stories.tsx
@@ -84,6 +84,20 @@ const customData = [{ title: 'r2204_1_0', value: 24, percentage: 166.992, percen
 { title: 'r1112_1_0', value: 22, percentage: 113.747, percentage_change: 5.7166473529, total: 0.193415712 },
 { title: 'r2110_1_0', value: 80, percentage: 304.77, percentage_change: 3.80969996, total: 0.2625626 }];
 
+const initialSortByCustomData = [
+    { title: 'car', value: 24, percentage: 166.992, percentage_change: 6.9579999999, total: 0.14371985 },
+    { title: 'truck', value: 22, percentage: 304.77, percentage_change: 15.814, total: 0.063491 },
+    { title: 'boat', value: 5, percentage: 25.68, percentage_change: 5.136, total: 0.1947675 },
+    { title: 'car', value: 51, percentage: 291.549, percentage_change: 5.7166473529, total: 0.1959277202 },
+    { title: 'boat', value: 51, percentage: 175.199, percentage_change: 4.4922282052, total: 0.2226686241 },
+    { title: 'car', value: 12, percentage: 80.672, percentage_change: 6.7266666, total: 0.148750612 },
+    { title: 'truck', value: 83, percentage: 275.087, percentage_change: 3.314819277, total: 0.3017716 },
+    { title: 'truck', value: 51, percentage: 130.419, percentage_change: 4.830333334, total: 0.20705373 },
+    { title: 'truck', value: 18, percentage: 97.505, percentage_change: 5.7166473529, total: 0.1746059897 },
+    { title: 'car', value: 22, percentage: 113.747, percentage_change: 5.7166473529, total: 0.193415712 },
+    { title: 'boat', value: 22, percentage: 47.442, percentage_change: 3.80969996, total: 0.2625626 }
+];
+
 const Template: Story<TableProps & ComponentPropsWithoutRef<'div'>> = (args) => {
     const [data, setData] = useState(args.data);
     const [dataToggle, setDataToggle] = useState(false);
@@ -93,15 +107,15 @@ const Template: Story<TableProps & ComponentPropsWithoutRef<'div'>> = (args) => 
         const newData = dataToggle ? customData : [];
         setData(newData);
         setDataToggle(dataToggle => !dataToggle);
-    }
+    };
 
     const handleSort = (_, sortedBy) => {
         const newMsg = 'Sorting is applied on column name(s): ' ;
         const columnNamesAndSortDirection = sortedBy.map((sortedColumn) => {
-            const colName = columns.find(col => col.accessor === sortedColumn.id).Header 
+            const colName = columns.find(col => col.accessor === sortedColumn.id).Header;
              const sortDirection = sortedColumn.desc ? '(Descending Order)' : '(Ascending Order)';
-             return ` ${colName} ${sortDirection}`
-        })
+             return ` ${colName} ${sortDirection}`;
+        });
 
         setSortMsg(`${newMsg} ${columnNamesAndSortDirection}`);
     };
@@ -120,12 +134,32 @@ const Template: Story<TableProps & ComponentPropsWithoutRef<'div'>> = (args) => 
     );
 };
 
+// initialSortBy one column
 export const Table = Template.bind({});
 Table.args = {
     columns: columns,
     data: customData,
     initialSortBy: { id: 'title', desc: false },
-    noDataMessage: "No data found",
+    noDataMessage: 'No data found',
+    options: {
+        disableSortRemove: true,
+        autoResetSortBy: true,
+        disableMultiSort: false
+    }
+};
+
+
+// initialSortBy array of which columns to sort in order
+export const TableWithInitialSortByArray = Template.bind({});
+TableWithInitialSortByArray.args = {
+    columns: columns,
+    data: initialSortByCustomData,
+    initialSortBy: [
+        {id: 'value', desc: false},
+        {id: 'title', desc: true},
+        {id: 'percentage', desc: true}
+    ],
+    noDataMessage: 'No data found',
     options: {
         disableSortRemove: true,
         autoResetSortBy: true,
@@ -138,7 +172,7 @@ TableWithMultiSortDisabled.args = {
     columns: columns,
     data: customData,
     initialSortBy: { id: 'title', desc: false },
-    noDataMessage: "No data found",
+    noDataMessage: 'No data found',
     options: {
         disableMultiSort: true
     }
@@ -149,7 +183,7 @@ TableWithCustomWidth.args = {
     columns: columnsWithWidth,
     data: customData,
     initialSortBy: { id: 'title', desc: false },
-    noDataMessage: "No data found",
+    noDataMessage: 'No data found',
     options: {
         disableMultiSort: false
     }


### PR DESCRIPTION
This PR is for updating the Table component specifically the initialSortBy. This will support an array of initialSortBy "ids" and if they are "desc" or not. This is for sorting columns in a table based on their initial desired sorting of multiple columns. Also still accepts one column value if desired. Added test and updated syntax that was missing.

![Screen Shot 2022-07-28 at 3 48 12 PM](https://user-images.githubusercontent.com/87024084/181624760-6d7121e2-1965-4b1f-bae9-c05f0d9b2dc9.png)


### Lakefront PR Checklist

- [x]  Exported any new components in the src/index.ts
- [x]  Updated the main README table.
- [x]  Ensure version numbers were bumped properly.
- [x]  Imported SVGs with relative path, if applicable.
- [x]  Removed any irrelevant commit messages from merge commit.
- [ ]  Deleted branch after merge.
