### PR TITLE
Cast url query param value(s) as UrlParameters and remove the type (string \ null)[]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.112.0",
+  "version": "0.112.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.112.0",
+      "version": "0.112.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.112.0",
+  "version": "0.112.1",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/Filter/Filter.tsx
+++ b/src/Filter/Filter.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useState } from 'react';
 import queryString from 'query-string';
-import { ContextSwitchMenuValue, FilterComponentProps, FilterMode } from './types';
+import { ContextSwitchMenuValue, FilterComponentProps, FilterMode, UrlParameters } from './types';
 import { FILTER_MODE_OPTIONS, getCurrentBrowserQueryParams, getDefaultJsonViewValue } from './util';
 import { ThemeProvider } from '@emotion/react';
 import {
@@ -40,7 +40,7 @@ export const Filter: FC<FilterComponentProps> = ({
     updateHistory,
     badgeThreshold = 4
 }) => {
-    const urlParams = queryString.parse(location.search);
+    const urlParams = queryString.parse(location.search) as UrlParameters;
     const [isCollapsedState, setIsCollapsedState] = useState(false);
     const [activeSection, setActiveSection] = useState(initialActiveSection);
     const [jsonQueryParams, setJsonQueryParams] = useState(        

--- a/src/Filter/types/index.ts
+++ b/src/Filter/types/index.ts
@@ -79,7 +79,7 @@ export interface FilterModule<T> {
     /**
      * Parses filter value from browser url query param value(s) and pre-populates the filter value on init.
      */
-    parseInitialFilterValue(browserQueryUrlValue?: string | string[] | (string | null)[] | null | undefined): T | null | undefined;
+    parseInitialFilterValue(browserQueryUrlValue?: string | string[] | null | undefined): T | null | undefined;
     /**
      * Renders the filter input controls in the left filter drawer.
      */

--- a/src/Filter/util/filterHooksUtil.tsx
+++ b/src/Filter/util/filterHooksUtil.tsx
@@ -1,5 +1,5 @@
 import queryString, { ParsedQuery } from 'query-string';
-import { FilterPostBody, FilterSet, FilterValues, Location } from '../types';
+import { FilterPostBody, FilterSet, FilterValues, Location, UrlParameters } from '../types';
 
 /**
  * Return the filter query string to be appended to API endpoint URL.
@@ -33,7 +33,7 @@ export const getApiPostBody = <T extends FilterPostBody = {}>(filters: FilterSet
  * pre-populate filter values on init.
  */
 export const parseInitialFilterValues = (location: Location, filters: FilterSet): FilterValues => {
-    const urlParams = queryString.parse(location.search);
+    const urlParams = queryString.parse(location.search) as UrlParameters;
     const initialFilterValues: FilterValues = {};
     Object.keys(filters).forEach((key) => {
         const filter = filters[key];       

--- a/src/Filter/util/filterUtil.ts
+++ b/src/Filter/util/filterUtil.ts
@@ -1,4 +1,4 @@
-import { FilterMode, FilterSet, FilterValues } from '../types';
+import { FilterMode, FilterSet, FilterValues, UrlParameters } from '../types';
 import queryString from 'query-string';
 
 /**
@@ -17,7 +17,7 @@ export const USER_JSON_QUERY_PARAM = 'userJSON';
 /**
  * Returns the default value or fallback value of a requested url parameter.
  */
-export const getDefaultValue = (urlParams: queryString.ParsedQuery<string>, key: string, defaultValue: any) => {
+export const getDefaultValue = (urlParams: UrlParameters, key: string, defaultValue: any) => {
     if (urlParams[key]) {
         return Array.isArray(urlParams[key]) ? urlParams[key]?.[0] : urlParams[key];
     }
@@ -28,7 +28,7 @@ export const getDefaultValue = (urlParams: queryString.ParsedQuery<string>, key:
 /**
  * Returns the default value of `jsonView` parameter.
  */
-export const getDefaultJsonViewValue = (urlParams: queryString.ParsedQuery<string>) => {
+export const getDefaultJsonViewValue = (urlParams: UrlParameters) => {
     const val = getDefaultValue(urlParams, 'jsonView', false);
 
     // value will be a string if provided as a query string


### PR DESCRIPTION
If approved, this will close https://github.com/ToyotaResearchInstitute/lakefront/issues/269.
In the file src/Filter/types/index.ts, remove the type (string | null)[]) from the function parseInitialFilterValue(browserQueryUrlValue?: string | string[] | null | undefined): T | null | undefined;

In the file src/Filter/util/filterHooksUtil.tsx, **location.search** should be cast as **UrlParameters**.
In the file src/Filter/util/filterUtil.ts, functions **getDefaultJsonViewValue**, **getDefaultValue** should take in an argument of type UrlParameters.
In the file src/Filter/Filter.tsx, location.search should be cast as **UrlParameters**.

### Lakefront PR Checklist

- [ ]  Exported any new components in the src/index.ts
- [ ]  Updated the main README table.
- [ ]  Ensure version numbers were bumped properly.
- [ ]  Imported SVGs with relative path, if applicable.
- [ ]  Removed any irrelevant commit messages from merge commit.
- [ ]  Deleted branch after merge.
