### PR TITLE
Expandable table rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.114.0",
+  "version": "0.114.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.114.0",
+      "version": "0.114.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.114.0",
+  "version": "0.114.1",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { useTable, useSortBy, useExpanded, TableState, Column, TableSortByToggleProps } from 'react-table';
-import { StyledHeader, StyledHeaderContent, TableStyle } from './tableStyles';
+import { HideableTHead, StyledHeader, StyledHeaderContent, TableStyle } from './tableStyles';
 import { ThemeProvider } from '@emotion/react';
 import theme from 'src/styles/theme';
 import { getSortBySVG, getTitleForMultiSort } from './tableUtil';
@@ -56,6 +56,11 @@ export interface TableProps {
      * This is to set the row sub component on the table.
      */
     renderRowSubComponent?({ row }: { row: any }): React.ReactNode;
+    /**
+     * This allows displaying the table rows without headers.
+     * This is defaulted to false.
+     */
+    hideHeaders?: boolean;
 }
 
 type CustomTableOptions = TableState<object> & { sortBy: SortByOptions[] }
@@ -75,7 +80,9 @@ const Table: React.FC<TableProps> = ({ className,
     onChangeSort,
     initialSortBy,
     rowProps,
-    renderRowSubComponent }) => {
+    renderRowSubComponent,
+    hideHeaders = false
+}) => {
         /** initalSortBy must be memoized
          * https://react-table-v7.tanstack.com/docs/api/useSortBy#table-options
          */
@@ -112,7 +119,7 @@ const Table: React.FC<TableProps> = ({ className,
         return (
             <ThemeProvider theme={theme}>
                 <TableStyle {...getTableProps()} className={className} style={style}>
-                    <thead>
+                    <HideableTHead hide={hideHeaders}>
                         {headerGroups.map((headerGroup: any) => (
                             <tr {...headerGroup.getHeaderGroupProps()}>
                                 {headerGroup.headers.map((column: any) => (
@@ -137,7 +144,7 @@ const Table: React.FC<TableProps> = ({ className,
                                 ))}
                             </tr>
                         ))}
-                    </thead>
+                    </HideableTHead>
                     <tbody {...getTableBodyProps()}>
                         {rows.map((row: any) => {
                             prepareRow(row);

--- a/src/Table/__tests__/Table.test.jsx
+++ b/src/Table/__tests__/Table.test.jsx
@@ -35,6 +35,21 @@ const customData = [{ title: 'r2204_1_0', value: 24, percentage: 166.992, percen
 { title: 'r2019_1_0', value: 51, percentage: 291.549, percentage_change: 5.7166473529, total: 0.1949277202 },
 { title: 'r2020_1_0', value: 31, percentage: 271.549, percentage_change: 5.7166473529, total: 0.1749277202 },
 { title: 'r2021_1_0', value: 41, percentage: 281.549, percentage_change: 5.7166473529, total: 0.1849277202 }];
+const columnsWithExpander = [
+    ...columns,
+    {
+        Header: '',
+        id: 'expander',
+        disableSortBy: true,
+        Cell: ({ row }) => {
+            return (
+                <div {...row.getToggleRowExpandedProps()}>
+                    {row.isExpanded ? '- collapse' : '+ expand'}
+                </div>
+            );
+        }
+    }
+];
 
 describe('<Table>', () => {
     it('renders properly', () => {
@@ -116,5 +131,46 @@ describe('<Table>', () => {
             initialSortBy={[{ id: 'value', desc: false }, { id: 'title', desc: true }, { id: 'percentage', desc: true }]} onChangeSort={mockHandleSort} />);
 
         expect(mockHandleSort).toHaveBeenCalledWith( {'desc': false, 'id': 'value'}, [{'desc': false, 'id': 'value'}, {'desc': true, 'id': 'title'}, {'desc': true, 'id': 'percentage'}]);
+    });
+
+    describe('table row expansion', () => {
+        const renderRowSubComponent = ({ row }) => {
+            const { value } = row.original;
+            return (
+                <div style={{ fontSize: '24px' }}>
+                    Value is {value}
+                </div>
+            );
+        };
+
+        it('renders the sub-row when row.expanded is true', () => {
+            const { queryByText, queryAllByText } = render(
+                <Table
+                    columns={columnsWithExpander}
+                    data={customData}
+                    renderRowSubComponent={renderRowSubComponent}
+                />
+            );
+
+            fireEvent.click(queryAllByText('+ expand')[0]);
+
+            expect(queryByText(`Value is ${customData[0].value}`)).toBeInTheDocument();
+        });
+
+        it('does not render the sub-row when row.expanded is false', () => {
+            const { queryByText, queryAllByText } = render(
+                <Table
+                    columns={columnsWithExpander}
+                    data={customData}
+                    renderRowSubComponent={renderRowSubComponent}
+                />
+            );
+
+            fireEvent.click(queryAllByText('+ expand')[0]);
+            expect(queryByText(`Value is ${customData[0].value}`)).toBeInTheDocument();
+
+            fireEvent.click(queryAllByText('- collapse')[0]);
+            expect(queryByText(`Value is ${customData[0].value}`)).not.toBeInTheDocument();
+        });
     });
 });

--- a/src/Table/__tests__/Table.test.jsx
+++ b/src/Table/__tests__/Table.test.jsx
@@ -133,6 +133,18 @@ describe('<Table>', () => {
         expect(mockHandleSort).toHaveBeenCalledWith( {'desc': false, 'id': 'value'}, [{'desc': false, 'id': 'value'}, {'desc': true, 'id': 'title'}, {'desc': true, 'id': 'percentage'}]);
     });
 
+    it('displays header row by default', () => {
+        const { container } = render(<Table columns={columns} data={customData} />);
+
+        expect(container.querySelector('thead')).toHaveStyle({ visibility: 'visible' });
+    });
+
+    it('hides header row when hideHeaders is true', () => {
+        const { container } = render(<Table columns={columns} data={customData} hideHeaders />);
+
+        expect(container.querySelector('thead')).toHaveStyle({ visibility: 'collapse' });
+    });
+
     describe('table row expansion', () => {
         const renderRowSubComponent = ({ row }) => {
             const { value } = row.original;

--- a/src/Table/__tests__/Table.test.jsx
+++ b/src/Table/__tests__/Table.test.jsx
@@ -37,14 +37,14 @@ const customData = [{ title: 'r2204_1_0', value: 24, percentage: 166.992, percen
 { title: 'r2021_1_0', value: 41, percentage: 281.549, percentage_change: 5.7166473529, total: 0.1849277202 }];
 
 describe('<Table>', () => {
-    it('check if table renders properly', () => {
+    it('renders properly', () => {
         const { container } = render(<Table columns={columns} data={customData} />);
 
         expect(container.querySelectorAll('tbody tr').length).toBe(6);
         expect(container.querySelector('table')).toHaveStyle('width: 100%;');
     });
 
-    it('checks if the column sorting is working', () => {
+    it('sorts columns correctly', () => {
         const mockHandleSort = jest.fn();
         const { container, getAllByRole } = render(<Table columns={columns} data={customData}
             initialSortBy={{ id: 'title', desc: false }} onChangeSort={mockHandleSort} />);
@@ -72,14 +72,14 @@ describe('<Table>', () => {
 
     });
 
-    it('check if message is displayed properly when data is not present', () => {
+    it('displays correct message when data is not present', () => {
         const { container } = render(<Table columns={columns} data={[]} noDataMessage='No data found' />);
 
         expect(container.innerHTML).toContain('No data found');
 
     });
 
-    it('check if the tooltip on the header indicates that multiple sort criteria is possible by shift-clicking to add to the sort.', () => {
+    it('displays tooltip on the header to indicate that multiple sort criteria is possible by shift-clicking to add to the sort.', () => {
         const { container } = render(<Table columns={columns} data={customData}
             initialSortBy={{ id: 'title', desc: false }} />);
 

--- a/src/Table/tableStyles.ts
+++ b/src/Table/tableStyles.ts
@@ -71,15 +71,23 @@ export const StyledHeaderContent = styled.div({
 export const StyledArrowDown = styled(ArrowDown)({
     paddingLeft: 5,
     paddingTop: 3
-})
+});
 
 export const StyledArrowUp = styled(ArrowUp)({
     paddingLeft: 5,
     paddingTop: 3
-})
+});
 
 export const StyledUnsorted = styled(Unsorted)({
     marginLeft: 8,
     position: 'relative',
     top: 10
-})
+});
+
+interface HideableTHeadProps {
+    hide: boolean;
+}
+
+export const HideableTHead = styled.thead<HideableTHeadProps>(({ hide }) => ({
+    visibility: hide ? 'collapse' : 'visible'
+}));

--- a/src/stories/Table/Table.stories.tsx
+++ b/src/stories/Table/Table.stories.tsx
@@ -22,7 +22,7 @@ const columns = [
     {
         Header: 'TITLE',
         accessor: 'title',
-        Cell: ({ cell: { value } }) => value
+        Cell: ({ cell: { value } }) => value,
     },
     {
         Header: 'VALUE',
@@ -82,8 +82,8 @@ const ChevronContainer = styled.div({
     }
 });
 
-const columnsWithExpander = [
-    ...columns,
+const columnsWithWidthAndExpander = [
+    ...columnsWithWidth,
     {
         Header: '',
         id: 'expander',
@@ -124,6 +124,16 @@ const initialSortByCustomData = [
     { title: 'boat', value: 22, percentage: 47.442, percentage_change: 3.80969996, total: 0.2625626 }
 ];
 
+const StyledTD = styled.td({
+    padding: '0 1em',
+    td: {
+        paddingLeft: 0
+    },
+    'td:first-of-type': {
+        padding: '0.8rem'
+    }
+});
+
 const renderRowSubComponent = ({ row }) => {
     const { value, percentage, percentage_change, total } = row.original;
     const nestedData = [
@@ -131,13 +141,27 @@ const renderRowSubComponent = ({ row }) => {
         { title: 'doubled', value: 24 * 2, percentage: percentage * 2, percentage_change: percentage_change  * 2, total: total * 2 },
     ];
 
+    const subColumns = [
+        ...columnsWithWidthAndExpander
+        .slice(0, columnsWithWidthAndExpander.length - 1),
+        {
+            Header: '',
+            id: 'hiddenExpander',
+            disableSortBy: true,
+            Cell: () => null
+        }
+    ];
+
     return (
-        <tr style={{ paddingLeft: '1em' }}>
-            <td colSpan={columns.length}>
-                <div>
-                    <TableComponent columns={columns} data={nestedData} renderRowSubComponent={renderRowSubComponent} />
-                </div>
-            </td>
+        <tr>
+            <StyledTD colSpan={columnsWithWidthAndExpander.length}>
+                <TableComponent
+                    columns={subColumns}
+                    data={nestedData}
+                    renderRowSubComponent={renderRowSubComponent}
+                    hideHeaders
+                />
+            </StyledTD>
         </tr>
     );
 };
@@ -247,7 +271,7 @@ TableWithCustomWidth.args = {
 
 export const TableWithExpandableRows = Template.bind({});
 TableWithExpandableRows.args = {
-    columns: columnsWithExpander,
+    columns: columnsWithWidthAndExpander,
     data: initialSortByCustomData,
     noDataMessage: 'No data found',
     renderRowSubComponent

--- a/src/stories/Table/Table.stories.tsx
+++ b/src/stories/Table/Table.stories.tsx
@@ -22,7 +22,7 @@ const columns = [
     {
         Header: 'TITLE',
         accessor: 'title',
-        Cell: ({ cell: { value } }) => value,
+        Cell: ({ cell: { value } }) => value
     },
     {
         Header: 'VALUE',
@@ -48,35 +48,37 @@ const columnsWithWidth = [
     {
         Header: 'TITLE',
         accessor: 'title',
-        width:100,
+        width: 100,
         Cell: ({ cell: { value } }) => value
     },
     {
         Header: 'VALUE',
         accessor: 'value',
-        width:100
+        width: 100
     },
     {
         Header: 'PERCENTAGE',
         accessor: 'percentage',
-        width:100
+        width: 100
     },
     {
         Header: 'PERCENTAGE CHANGE',
         accessor: 'percentage_change',
-        width:140,
+        width: 140,
         Cell: ({ cell: { value } }) => value?.toFixed(4) || ''
     },
     {
         Header: 'TOTAL/100',
         accessor: 'total',
-        width:50,
+        width: 50,
         disableSortBy: true,
         Cell: ({ cell: { value } }) => value?.toFixed(4) || ''
     }
 ];
 
 const ChevronContainer = styled.div({
+    display: 'flex',
+    justifyContent: 'center',
     svg: {
         stroke: lakefrontColors.black
     }
@@ -98,17 +100,23 @@ const columnsWithWidthAndExpander = [
     }
 ];
 
-const customData = [{ title: 'r2204_1_0', value: 24, percentage: 166.992, percentage_change: 6.9579999999, total: 0.14371985 },
-{ title: 'r2002_1_0', value: 3, percentage: 47.442, percentage_change: 15.814, total: 0.063491 },
-{ title: 'r2010_1_0', value: 5, percentage: 25.68, percentage_change: 5.136, total: 0.1947675 },
-{ title: 'r2019_1_0', value: 51, percentage: 291.549, percentage_change: 5.7166473529, total: 0.1959277202 },
-{ title: 'r2125_1_0', value: 39, percentage: 175.199, percentage_change: 4.4922282052, total: 0.2226686241 },
-{ title: 'r2018_1_0', value: 12, percentage: 80.672, percentage_change: 6.7266666, total: 0.148750612 },
-{ title: 'r2027_1_0', value: 83, percentage: 275.087, percentage_change: 3.314819277, total: 0.3017716 },
-{ title: 'r2016_1_0', value: 27, percentage: 130.419, percentage_change: 4.830333334, total: 0.20705373 },
-{ title: 'r2115_1_0', value: 18, percentage: 97.505, percentage_change: 5.7166473529, total: 0.1746059897 },
-{ title: 'r1112_1_0', value: 22, percentage: 113.747, percentage_change: 5.7166473529, total: 0.193415712 },
-{ title: 'r2110_1_0', value: 80, percentage: 304.77, percentage_change: 3.80969996, total: 0.2625626 }];
+const customData = [{
+    title: 'r2204_1_0',
+    value: 24,
+    percentage: 166.992,
+    percentage_change: 6.9579999999,
+    total: 0.14371985
+},
+    { title: 'r2002_1_0', value: 3, percentage: 47.442, percentage_change: 15.814, total: 0.063491 },
+    { title: 'r2010_1_0', value: 5, percentage: 25.68, percentage_change: 5.136, total: 0.1947675 },
+    { title: 'r2019_1_0', value: 51, percentage: 291.549, percentage_change: 5.7166473529, total: 0.1959277202 },
+    { title: 'r2125_1_0', value: 39, percentage: 175.199, percentage_change: 4.4922282052, total: 0.2226686241 },
+    { title: 'r2018_1_0', value: 12, percentage: 80.672, percentage_change: 6.7266666, total: 0.148750612 },
+    { title: 'r2027_1_0', value: 83, percentage: 275.087, percentage_change: 3.314819277, total: 0.3017716 },
+    { title: 'r2016_1_0', value: 27, percentage: 130.419, percentage_change: 4.830333334, total: 0.20705373 },
+    { title: 'r2115_1_0', value: 18, percentage: 97.505, percentage_change: 5.7166473529, total: 0.1746059897 },
+    { title: 'r1112_1_0', value: 22, percentage: 113.747, percentage_change: 5.7166473529, total: 0.193415712 },
+    { title: 'r2110_1_0', value: 80, percentage: 304.77, percentage_change: 3.80969996, total: 0.2625626 }];
 
 const initialSortByCustomData = [
     { title: 'car', value: 24, percentage: 166.992, percentage_change: 6.9579999999, total: 0.14371985 },
@@ -124,45 +132,66 @@ const initialSortByCustomData = [
     { title: 'boat', value: 22, percentage: 47.442, percentage_change: 3.80969996, total: 0.2625626 }
 ];
 
-const StyledTD = styled.td({
-    padding: '0 1em',
-    td: {
-        paddingLeft: 0
+const SubComponentTr = styled.tr({
+    'td.table-wrapper-td': {
+        padding: 0
     },
-    'td:first-of-type': {
-        padding: '0.8rem'
+    boxShadow: '0px 4px 4px #F5F5F5'
+});
+
+const TableWrapperTd = styled.td({
+    'td:first-of-type, td:last-of-type': {
+        content: '""',
+        display: 'block',
+        margin: '0 auto 0 1em',
+        borderBottom: `1px solid ${lakefrontColors.selago}`
+    },
+    'td:last-of-type': {
+        margin: '0 1em 0 auto'
     }
 });
 
 const renderRowSubComponent = ({ row }) => {
     const { value, percentage, percentage_change, total } = row.original;
     const nestedData = [
-        { title: 'halved', value: value / 2, percentage: percentage / 2, percentage_change: percentage_change / 2, total: total / 2 },
-        { title: 'doubled', value: 24 * 2, percentage: percentage * 2, percentage_change: percentage_change  * 2, total: total * 2 },
+        {
+            title: 'halved',
+            value: value / 2,
+            percentage: percentage / 2,
+            percentage_change: percentage_change / 2,
+            total: total / 2
+        },
+        {
+            title: 'doubled',
+            value: 24 * 2,
+            percentage: percentage * 2,
+            percentage_change: percentage_change * 2,
+            total: total * 2
+        }
     ];
 
     const subColumns = [
         ...columnsWithWidthAndExpander
-        .slice(0, columnsWithWidthAndExpander.length - 1),
+            .slice(0, columnsWithWidthAndExpander.length - 1),
         {
             Header: '',
             id: 'hiddenExpander',
             disableSortBy: true,
-            Cell: () => null
+            Cell: () => <div>&nbsp;</div>
         }
     ];
 
     return (
-        <tr>
-            <StyledTD colSpan={columnsWithWidthAndExpander.length}>
+        <SubComponentTr>
+            <TableWrapperTd colSpan={columnsWithWidthAndExpander.length} className='table-wrapper-td'>
                 <TableComponent
                     columns={subColumns}
                     data={nestedData}
                     renderRowSubComponent={renderRowSubComponent}
                     hideHeaders
                 />
-            </StyledTD>
-        </tr>
+            </TableWrapperTd>
+        </SubComponentTr>
     );
 };
 
@@ -189,11 +218,11 @@ const Template: Story<TableProps & ComponentPropsWithoutRef<'div'>> = (args) => 
     };
 
     const handleSort = (_, sortedBy) => {
-        const newMsg = 'Sorting is applied on column name(s): ' ;
+        const newMsg = 'Sorting is applied on column name(s): ';
         const columnNamesAndSortDirection = sortedBy.map((sortedColumn) => {
             const colName = columns.find(col => col.accessor === sortedColumn.id).Header;
-             const sortDirection = sortedColumn.desc ? '(Descending Order)' : '(Ascending Order)';
-             return ` ${colName} ${sortDirection}`;
+            const sortDirection = sortedColumn.desc ? '(Descending Order)' : '(Ascending Order)';
+            return ` ${colName} ${sortDirection}`;
         });
 
         setSortMsg(`${newMsg} ${columnNamesAndSortDirection}`);
@@ -235,9 +264,9 @@ TableWithInitialSortByArray.args = {
     columns: columns,
     data: initialSortByCustomData,
     initialSortBy: [
-        {id: 'value', desc: false},
-        {id: 'title', desc: true},
-        {id: 'percentage', desc: true}
+        { id: 'value', desc: false },
+        { id: 'title', desc: true },
+        { id: 'percentage', desc: true }
     ],
     noDataMessage: 'No data found',
     options: {

--- a/src/stories/Table/Table.stories.tsx
+++ b/src/stories/Table/Table.stories.tsx
@@ -3,6 +3,10 @@ import { Meta, Story } from '@storybook/react/types-6-0';
 import Button from 'src/Button/Button';
 import TableComponent, { TableProps } from 'src/Table';
 import DocBlock from '.storybook/DocBlock';
+import styled from '@emotion/styled';
+import { ReactComponent as ChevronUp } from 'src/Collapsible/assets/chevron-up.svg';
+import { ReactComponent as ChevronDown } from 'src/Collapsible/assets/chevron-down.svg';
+import lakefrontColors from 'src/styles/lakefrontColors';
 
 export default {
     title: 'Lakefront/Table',
@@ -72,6 +76,28 @@ const columnsWithWidth = [
     }
 ];
 
+const ChevronContainer = styled.div({
+    svg: {
+        stroke: lakefrontColors.black
+    }
+});
+
+const columnsWithExpander = [
+    ...columns,
+    {
+        Header: '',
+        id: 'expander',
+        disableSortBy: true,
+        Cell: ({ row }) => {
+            return (
+                <ChevronContainer {...row.getToggleRowExpandedProps()}>
+                    {row.isExpanded ? <ChevronUp /> : <ChevronDown />}
+                </ChevronContainer>
+            );
+        }
+    }
+];
+
 const customData = [{ title: 'r2204_1_0', value: 24, percentage: 166.992, percentage_change: 6.9579999999, total: 0.14371985 },
 { title: 'r2002_1_0', value: 3, percentage: 47.442, percentage_change: 15.814, total: 0.063491 },
 { title: 'r2010_1_0', value: 5, percentage: 25.68, percentage_change: 5.136, total: 0.1947675 },
@@ -98,6 +124,35 @@ const initialSortByCustomData = [
     { title: 'boat', value: 22, percentage: 47.442, percentage_change: 3.80969996, total: 0.2625626 }
 ];
 
+const renderRowSubComponent = ({ row }) => {
+    const { value, percentage, percentage_change, total } = row.original;
+    const nestedData = [
+        { title: 'halved', value: value / 2, percentage: percentage / 2, percentage_change: percentage_change / 2, total: total / 2 },
+        { title: 'doubled', value: 24 * 2, percentage: percentage * 2, percentage_change: percentage_change  * 2, total: total * 2 },
+    ];
+
+    return (
+        <tr style={{ paddingLeft: '1em' }}>
+            <td colSpan={columns.length}>
+                <div>
+                    <TableComponent columns={columns} data={nestedData} renderRowSubComponent={renderRowSubComponent} />
+                </div>
+            </td>
+        </tr>
+    );
+};
+
+const StyledTableComponent = styled(TableComponent)({
+    td: {
+        fontWeight: 'bold'
+    },
+    table: {
+        td: {
+            fontWeight: 'normal'
+        }
+    }
+});
+
 const Template: Story<TableProps & ComponentPropsWithoutRef<'div'>> = (args) => {
     const [data, setData] = useState(args.data);
     const [dataToggle, setDataToggle] = useState(false);
@@ -120,6 +175,8 @@ const Template: Story<TableProps & ComponentPropsWithoutRef<'div'>> = (args) => 
         setSortMsg(`${newMsg} ${columnNamesAndSortDirection}`);
     };
 
+    const RenderTableComponent = args.renderRowSubComponent ? StyledTableComponent : TableComponent;
+
     return (
         <>
             <div style={{ marginTop: '10px', marginLeft: '10px' }}>
@@ -128,8 +185,7 @@ const Template: Story<TableProps & ComponentPropsWithoutRef<'div'>> = (args) => 
                 {!dataToggle && <b>{sortMsg}</b>
                 }
             </div>
-            <TableComponent {...args} data={data} onChangeSort={handleSort}>
-            </TableComponent>
+            <RenderTableComponent {...args} data={data} onChangeSort={handleSort} />
         </>
     );
 };
@@ -187,4 +243,12 @@ TableWithCustomWidth.args = {
     options: {
         disableMultiSort: false
     }
+};
+
+export const TableWithExpandableRows = Template.bind({});
+TableWithExpandableRows.args = {
+    columns: columnsWithExpander,
+    data: initialSortByCustomData,
+    noDataMessage: 'No data found',
+    renderRowSubComponent
 };


### PR DESCRIPTION
This PR is for adding an expandable `Table` rows story and adding the ability to hide table headers. If approved, this will close #283 .

![image](https://user-images.githubusercontent.com/80778550/189726537-ecc9aacf-1242-40e8-8407-1f16d681604f.png)


### Lakefront PR Checklist

- [ ]  Exported any new components in the src/index.ts
- [ ]  Updated the main README table.
- [ ]  Ensure version numbers were bumped properly.
- [ ]  Imported SVGs with relative path, if applicable.
- [ ]  Removed any irrelevant commit messages from merge commit.
- [ ]  Deleted branch after merge.
