### PR TITLE
Snackbar message types export fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.121.2",
+  "version": "0.121.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.121.2",
+      "version": "0.121.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.121.2",
+  "version": "0.121.3",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/components/Snackbar/index.ts
+++ b/src/components/Snackbar/index.ts
@@ -1,5 +1,5 @@
 import Snackbar, { SnackbarProps } from './Snackbar';
-import { MESSAGE_TYPES as SNACKBAR_MESSAGE_TYPES } from './Snackbar.util';
+import { MESSAGE_TYPES } from './Snackbar.util';
 
-export { SnackbarProps, SNACKBAR_MESSAGE_TYPES };
+export { SnackbarProps, MESSAGE_TYPES as SNACKBAR_MESSAGE_TYPES };
 export default Snackbar;


### PR DESCRIPTION
This is a quick PR to fix the way the snackbar message types enum is exported. The way it was changed the export from an enum to a value which caused issue in consuming applications.

### Lakefront PR Checklist

- [x]  Exported any new components in the src/index.ts
- [x]  Updated the main README table.
- [x]  Ensure version numbers were bumped properly.
- [x]  Imported SVGs with relative path, if applicable.
- [ ]  Removed any irrelevant commit messages from merge commit.
- [ ]  Deleted branch after merge.
