### PR TITLE
ListFilter default all options fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.124.0",
+  "version": "0.125.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.124.0",
+      "version": "0.125.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.127.0",
+  "version": "0.128.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.127.0",
+      "version": "0.128.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.123.1",
+  "version": "0.124.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.123.1",
+      "version": "0.124.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.125.0",
+  "version": "0.125.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.125.0",
+      "version": "0.125.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.123.0",
+  "version": "0.123.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.123.0",
+      "version": "0.123.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.126.0",
+  "version": "0.127.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.126.0",
+      "version": "0.127.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.125.1",
+  "version": "0.126.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.125.1",
+      "version": "0.126.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.123.1",
+  "version": "0.124.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.127.0",
+  "version": "0.128.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.123.0",
+  "version": "0.123.1",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.124.0",
+  "version": "0.125.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.125.1",
+  "version": "0.126.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.125.0",
+  "version": "0.125.1",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.126.0",
+  "version": "0.127.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/components/Filter/modules/ListFilter/ListFilter.tsx
+++ b/src/components/Filter/modules/ListFilter/ListFilter.tsx
@@ -1,7 +1,6 @@
-import { getUrlFromList } from 'src/components/Filter/util/filterUtil';
+import { areSetsEqual, getUrlFromList } from 'src/components/Filter/util/filterUtil';
 import CheckboxGroup, { CheckboxGroupOption } from 'src/components/CheckboxGroup/CheckboxGroup';
 import { FilterModule, ListFilterOverrides } from 'src/components/Filter/types';
-import * as R from 'ramda';
 
 export interface ListFilterOptions {
     allLabel?: string;
@@ -60,10 +59,9 @@ const ListFilter = (
             return value.size === options.length;
         }
         if (value && listFilterOptions.initialValue) {
-            const sortedInitialValueSet = new Set([listFilterOptions.initialValue].flat().sort());
-            const [sortedValue] = [value].flat().sort();
+            const initialValueSet = new Set([listFilterOptions.initialValue].flat());
 
-            return R.equals(sortedValue, sortedInitialValueSet);
+            return areSetsEqual(initialValueSet, value);
         }
         return false;
     },

--- a/src/components/Filter/modules/ListFilter/ListFilter.tsx
+++ b/src/components/Filter/modules/ListFilter/ListFilter.tsx
@@ -47,16 +47,19 @@ const ListFilter = (
         }
     },
     getBrowserQueryUrlValue: value => value && Array.from(value),
-    getDefaultFilterValue: () => new Set(options.map(item => item.value)),
+    getDefaultFilterValue: () => new Set(),
     isDefaultFilterValue: value => {
         if (value) {
+            console.log('value', value);
             if (value.size === 0) {
                 return true;
             }
-            return value.size === options.length;
+            return value.size === listFilterOptions.initialValue?.length;
         }
         return false;
     },
+
+
     getFilterBarLabel: value => {
         if (value) {
             return Array.from(value)
@@ -74,7 +77,7 @@ const ListFilter = (
                 .map(item => {
                     const itemLabel = options.find(i => i.value === item);
                     return String(itemLabel?.label);
-                })
+                });
         }
         return [];
     },
@@ -101,6 +104,7 @@ const ListFilter = (
             options={options}
             selected={value}
             allLabel={listFilterOptions.allLabel}
+            // children={listFilterOptions.initialValue}
         />
     ),
     ...listFilterOverrides,

--- a/src/components/Filter/modules/ListFilter/ListFilter.tsx
+++ b/src/components/Filter/modules/ListFilter/ListFilter.tsx
@@ -1,6 +1,7 @@
 import { getUrlFromList } from 'src/components/Filter/util/filterUtil';
 import CheckboxGroup, { CheckboxGroupOption } from 'src/components/CheckboxGroup/CheckboxGroup';
 import { FilterModule, ListFilterOverrides } from 'src/components/Filter/types';
+import * as R from 'ramda';
 
 export interface ListFilterOptions {
     allLabel?: string;
@@ -59,8 +60,9 @@ const ListFilter = (
             return value.size === options.length;
         }
         if (value && listFilterOptions.initialValue) {
-            const initialValueSet = new Set([listFilterOptions.initialValue].flat());
-            return value.size === initialValueSet.size;
+            const initialValueSet = new Set([listFilterOptions.initialValue].flat().sort());
+
+            return R.equals(value, initialValueSet);
         }
         return false;
     },

--- a/src/components/Filter/modules/ListFilter/ListFilter.tsx
+++ b/src/components/Filter/modules/ListFilter/ListFilter.tsx
@@ -60,9 +60,10 @@ const ListFilter = (
             return value.size === options.length;
         }
         if (value && listFilterOptions.initialValue) {
-            const initialValueSet = new Set([listFilterOptions.initialValue].flat().sort());
+            const sortedInitialValueSet = new Set([listFilterOptions.initialValue].flat().sort());
+            const [sortedValue] = [value].flat().sort();
 
-            return R.equals(value, initialValueSet);
+            return R.equals(sortedValue, sortedInitialValueSet);
         }
         return false;
     },

--- a/src/components/Filter/modules/ListFilter/ListFilter.tsx
+++ b/src/components/Filter/modules/ListFilter/ListFilter.tsx
@@ -34,7 +34,7 @@ const ListFilter = (
     getFilterCount: (value) => value?.size ?? 0,
     getApiQueryUrl: (key, value) => {
         if (value) {
-            return getUrlFromList(key, value, options.length);
+            return getUrlFromList(key, value, options.length, Boolean(listFilterOptions.initialValue));
         }
         return '';
     },
@@ -47,14 +47,20 @@ const ListFilter = (
         }
     },
     getBrowserQueryUrlValue: value => value && Array.from(value),
-    getDefaultFilterValue: () => new Set(),
+    getDefaultFilterValue: () => listFilterOptions.initialValue ?
+        new Set([listFilterOptions.initialValue].flat()) :
+        new Set(options.map(item => item.value)),
+
     isDefaultFilterValue: value => {
-        if (value) {
-            console.log('value', value);
+        if (value && !listFilterOptions.initialValue) {
             if (value.size === 0) {
                 return true;
             }
-            return value.size === listFilterOptions.initialValue?.length;
+            return value.size === options.length;
+        }
+        if (value && listFilterOptions.initialValue) {
+            const initialValueSet = new Set([listFilterOptions.initialValue].flat());
+            return value.size === initialValueSet.size;
         }
         return false;
     },
@@ -104,7 +110,6 @@ const ListFilter = (
             options={options}
             selected={value}
             allLabel={listFilterOptions.allLabel}
-            // children={listFilterOptions.initialValue}
         />
     ),
     ...listFilterOverrides,

--- a/src/components/Filter/modules/ListFilter/__tests__/listFilter.test.js
+++ b/src/components/Filter/modules/ListFilter/__tests__/listFilter.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import ListFilter from '../ListFilter';
-import { listFilterOptions } from '../../../../../stories/Filter/ListFilter/listFilterUtil';
+import { listFilterOptions } from 'src/stories/Filter/ListFilter/listFilterUtil';
 
 const options = [
     {
@@ -45,6 +45,11 @@ describe('ListFilter', () => {
             expect(getApiQueryUrl('a', setValue)).toBe('&a=test+1&a=test+2');
         });
 
+        it('returns an empty url when no initialValue is provided and the current setValue === length of options', () => {
+            const { getApiQueryUrl } = ListFilter(options, '', '', {});
+            expect(getApiQueryUrl('a', new Set(options))).toBe('');
+        });
+
         it('returns the proper url when there is a value with no initialValue', () => {
             const { getApiQueryUrl } = ListFilter(options, '', '');
             expect(getApiQueryUrl('a', new Set(['first name']))).toBe('&a=first+name');
@@ -67,7 +72,7 @@ describe('ListFilter', () => {
 
         it('returns an empty string when value is falsy', () => {
             const { getApiQueryUrl } = ListFilter(options, '', '');
-            expect(getApiQueryUrl('a', new Set())).toBe('');
+            expect(getApiQueryUrl('a', '')).toBe('');
             expect(getApiQueryUrl('a', null)).toBe('');
         });
     });

--- a/src/components/Filter/modules/ListFilter/__tests__/listFilter.test.js
+++ b/src/components/Filter/modules/ListFilter/__tests__/listFilter.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import ListFilter from '../ListFilter';
 import { listFilterOptions } from '../../../../../stories/Filter/ListFilter/listFilterUtil';
 
@@ -29,7 +29,7 @@ describe('ListFilter', () => {
         const { getFilterCount } = ListFilter(options, '', '');
 
         it('returns the the value size', () => {
-            expect(getFilterCount(new Set([1,2,3]))).toBe(3);
+            expect(getFilterCount(new Set([1, 2, 3]))).toBe(3);
         });
 
         it('returns 0 when a falsy value is provided', () => {
@@ -39,17 +39,36 @@ describe('ListFilter', () => {
     });
 
     describe('getApiQueryUrl', () => {
-        const { getApiQueryUrl } = ListFilter(options, '', '', { initialValue: 'first name' });
+        it('returns the proper url when initialValue and option values are equal', () => {
+            const { getApiQueryUrl } = ListFilter(options, '', '', { initialValue: options.map(initial => initial.value) });
+            const setValue = new Set(options.map(initial => initial.value));
+            expect(getApiQueryUrl('a', setValue)).toBe('&a=test+1&a=test+2');
+        });
 
-        it('returns the proper url when there is a value', () => {
-            expect(getApiQueryUrl('a', ['first name'])).toBe('&a=first+name');
+        it('returns the proper url when there is a value with no initialValue', () => {
+            const { getApiQueryUrl } = ListFilter(options, '', '');
+            expect(getApiQueryUrl('a', new Set(['first name']))).toBe('&a=first+name');
+        });
+
+        it('returns empty url when key && value are undefined', () => {
+            const { getApiQueryUrl } = ListFilter(options, '', '');
+            expect(getApiQueryUrl(undefined, undefined)).toBe('');
+        });
+
+        it('returns empty url when value is undefined', () => {
+            const { getApiQueryUrl } = ListFilter(options, '', '');
+            expect(getApiQueryUrl('a', undefined)).toBe('');
+        });
+
+        it('returns undefined url when key is undefined', () => {
+            const { getApiQueryUrl } = ListFilter(options, '', '');
+            expect(getApiQueryUrl(undefined, new Set(['a']))).toBe('&undefined=a');
         });
 
         it('returns an empty string when value is falsy', () => {
-            expect(getApiQueryUrl('a', '')).toBe('');
+            const { getApiQueryUrl } = ListFilter(options, '', '');
+            expect(getApiQueryUrl('a', new Set())).toBe('');
             expect(getApiQueryUrl('a', null)).toBe('');
-            expect(getApiQueryUrl('a', 0)).toBe('');
-            expect(getApiQueryUrl('a')).toBe('');
         });
     });
 
@@ -86,25 +105,45 @@ describe('ListFilter', () => {
     });
 
     describe('getDefaultFilterValue', () => {
-        const { getDefaultFilterValue } = ListFilter(options, '', '', {initialValue: options[0].value});
-
-        it('returns a default set based on the options', () => {
+        it('returns a default set when initialValue is provided', () => {
+            const { getDefaultFilterValue } = ListFilter(options, '', '', { initialValue: options[0].value });
             const defaultValues = new Set([options[0].value]);
 
             expect(getDefaultFilterValue('a')).toStrictEqual(defaultValues);
             expect(getDefaultFilterValue(1)).toStrictEqual(defaultValues);
             expect(getDefaultFilterValue()).toStrictEqual(defaultValues);
         });
+
+        it('returns a default set when initialValue is not provided', () => {
+            const { getDefaultFilterValue } = ListFilter(options, '', '');
+
+            expect(getDefaultFilterValue()).toStrictEqual(new Set([options[0].value, options[1].value]));
+        });
     });
 
     describe('isDefaultFilterValue', () => {
-        const { isDefaultFilterValue } = ListFilter(options, '', '', false);
-        const defaultValues = new Set([options[0].value, options[1].value]);
+        it('returns true if value is equal to empty string or empty Set', () => {
+            const { isDefaultFilterValue } = ListFilter(options, '', '');
+            const defaultValues = new Set([options[0].value, options[1].value]);
 
-        it('returns true if value is equal to empty string', () => {
             expect(isDefaultFilterValue(defaultValues)).toBe(true);
             expect(isDefaultFilterValue('a')).toBe(false);
             expect(isDefaultFilterValue()).toBe(false);
+            expect(isDefaultFilterValue(new Set(null))).toBe(true);
+        });
+
+        it('returns true when value and initialValue are truthy', () => {
+            const { isDefaultFilterValue } = ListFilter(options, '', '', { initialValue: [options[0].value, options[1].value] });
+            const defaultValues = new Set(['test 1', 'test 2']);
+
+            expect(isDefaultFilterValue(defaultValues)).toBe(true);
+        });
+
+        it('returns false when value and initialValue are falsy', () => {
+            const { isDefaultFilterValue } = ListFilter(options, '', '', { initialValue: [options[0].value, options[1].value] });
+            const defaultValues = new Set(['a', 'b']);
+
+            expect(isDefaultFilterValue(defaultValues)).toBe(false);
         });
     });
 
@@ -126,7 +165,7 @@ describe('ListFilter', () => {
         const oneOption = new Set([options[0].value]);
 
         it('returns array of values provided', () => {
-            expect(getFilterSectionLabel(allOptions)).toMatchObject(['Test 1','Test 2']);
+            expect(getFilterSectionLabel(allOptions)).toMatchObject(['Test 1', 'Test 2']);
             expect(getFilterSectionLabel(oneOption)).toMatchObject(['Test 1']);
         });
 

--- a/src/components/Filter/modules/ListFilter/__tests__/listFilter.test.js
+++ b/src/components/Filter/modules/ListFilter/__tests__/listFilter.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import ListFilter from '../ListFilter';
+import { listFilterOptions } from '../../../../../stories/Filter/ListFilter/listFilterUtil';
 
 const options = [
     {
@@ -38,7 +39,7 @@ describe('ListFilter', () => {
     });
 
     describe('getApiQueryUrl', () => {
-        const { getApiQueryUrl } = ListFilter(options, '', '');
+        const { getApiQueryUrl } = ListFilter(options, '', '', { initialValue: 'first name' });
 
         it('returns the proper url when there is a value', () => {
             expect(getApiQueryUrl('a', ['first name'])).toBe('&a=first+name');
@@ -85,10 +86,10 @@ describe('ListFilter', () => {
     });
 
     describe('getDefaultFilterValue', () => {
-        const { getDefaultFilterValue } = ListFilter(options, '', '');
+        const { getDefaultFilterValue } = ListFilter(options, '', '', {initialValue: options[0].value});
 
         it('returns a default set based on the options', () => {
-            const defaultValues = new Set([options[0].value, options[1].value]);
+            const defaultValues = new Set([options[0].value]);
 
             expect(getDefaultFilterValue('a')).toStrictEqual(defaultValues);
             expect(getDefaultFilterValue(1)).toStrictEqual(defaultValues);
@@ -97,7 +98,7 @@ describe('ListFilter', () => {
     });
 
     describe('isDefaultFilterValue', () => {
-        const { isDefaultFilterValue } = ListFilter(options, '', '');
+        const { isDefaultFilterValue } = ListFilter(options, '', '', false);
         const defaultValues = new Set([options[0].value, options[1].value]);
 
         it('returns true if value is equal to empty string', () => {

--- a/src/components/Filter/util/__tests__/filterUtil.test.js
+++ b/src/components/Filter/util/__tests__/filterUtil.test.js
@@ -88,4 +88,14 @@ describe('getUrlFromList', () => {
             expect(getUrlFromList('item', new Set(), 2)).toBe('');
         });
     });
+
+    describe('when initialValue is passed', () => {
+        it('returns the full url when initial value is true', () => {
+            expect(getUrlFromList('item', new Set(['good', 'better', 'best']), 3, true)).toBe('&item=good&item=better&item=best');
+        });
+
+        it('returns "" when initial value is false with all options selected', () => {
+            expect(getUrlFromList('item', new Set(['good', 'better', 'best']), 3, false)).toBe('');
+        });
+    });
 });

--- a/src/components/Filter/util/__tests__/filterUtil.test.js
+++ b/src/components/Filter/util/__tests__/filterUtil.test.js
@@ -1,4 +1,10 @@
-import { getDefaultValue, getDefaultJsonViewValue, getFilterAppliedCount, getUrlFromList } from '../filterUtil';
+import {
+    getDefaultValue,
+    getDefaultJsonViewValue,
+    getFilterAppliedCount,
+    getUrlFromList,
+    areSetsEqual
+} from '../filterUtil';
 import { FILTERS } from 'src/components/Filter/__tests__/filter.data';
 
 describe('getDefaultValue', () => {
@@ -96,6 +102,19 @@ describe('getUrlFromList', () => {
 
         it('returns "" when initial value is false with all options selected', () => {
             expect(getUrlFromList('item', new Set(['good', 'better', 'best']), 3, false)).toBe('');
+        });
+    });
+
+    describe('areSetsEqual', () => {
+        const initialValueSet = new Set(['better']);
+        it('returns expected results when comparing equal Sets ', () => {
+            const valueSet = new Set(['better']);
+            expect(areSetsEqual(initialValueSet, valueSet)).toBe(true);
+        });
+
+        it('returns expected results when comparing non equal Sets ', () => {
+            const valueSet = new Set(['best']);
+            expect(areSetsEqual(initialValueSet, valueSet)).toBe(false);
         });
     });
 });

--- a/src/components/Filter/util/filterUtil.ts
+++ b/src/components/Filter/util/filterUtil.ts
@@ -53,7 +53,7 @@ export const getFilterAppliedCount = (filters: FilterSet, filterValues: FilterVa
  * Default behavior is that when all items are selected, nothing is returned.
  */
 
-export const getUrlFromList = (name: string, list: string[] | Set<string>, count: number, initialValue?: boolean) => {
+export const getUrlFromList = (name: string, list: string[] | Set<string>, count: number, initialValue: boolean = false) => {
     const listSize = Array.isArray(list) ? list.length : list.size;
 
     // if all items in list selected, pass empty string in url filter

--- a/src/components/Filter/util/filterUtil.ts
+++ b/src/components/Filter/util/filterUtil.ts
@@ -52,11 +52,12 @@ export const getFilterAppliedCount = (filters: FilterSet, filterValues: FilterVa
  * Given a list (Array or Set) of string, return a query string representation.
  * Default behavior is that when all items are selected, nothing is returned.
  */
-export const getUrlFromList = (name: string, list: string[] | Set<string>, count: number) => {
+
+export const getUrlFromList = (name: string, list: string[] | Set<string>, count: number, initialValue?: boolean) => {
     const listSize = Array.isArray(list) ? list.length : list.size;
 
     // if all items in list selected, pass empty string in url filter
-    if (listSize === count || listSize === 0) {
+    if ((listSize === count || listSize === 0) && !initialValue) {
         return '';
     }
 

--- a/src/components/Filter/util/filterUtil.ts
+++ b/src/components/Filter/util/filterUtil.ts
@@ -67,3 +67,8 @@ export const getUrlFromList = (name: string, list: string[] | Set<string>, count
     }
     return `&${url}`;
 };
+
+// compare Set values
+export const areSetsEqual = (xs: Set<string>, ys: Set<string>) => {
+   return xs.size === ys.size && [...xs].every((x) => ys.has(x));
+};

--- a/src/components/Filter/util/filterUtil.ts
+++ b/src/components/Filter/util/filterUtil.ts
@@ -52,12 +52,11 @@ export const getFilterAppliedCount = (filters: FilterSet, filterValues: FilterVa
  * Given a list (Array or Set) of string, return a query string representation.
  * Default behavior is that when all items are selected, nothing is returned.
  */
-
-export const getUrlFromList = (name: string, list: string[] | Set<string>, count: number, initialValue: boolean = false) => {
+export const getUrlFromList = (name: string, list: string[] | Set<string>, count: number, hasInitialValue: boolean = false) => {
     const listSize = Array.isArray(list) ? list.length : list.size;
 
     // if all items in list selected, pass empty string in url filter
-    if ((listSize === count || listSize === 0) && !initialValue) {
+    if ((listSize === count || listSize === 0) && !hasInitialValue) {
         return '';
     }
 

--- a/src/stories/Filter/ListFilter/ListFilter.stories.tsx
+++ b/src/stories/Filter/ListFilter/ListFilter.stories.tsx
@@ -41,7 +41,16 @@ const ListFilterTemplate: Story = (args: ListFilterArgs) => {
     return <FilterPage pageFilters={pageFilters} />;
 };
 
+ const ListFilterTemplateOneValue: Story = (args: ListFilterArgs) => {
+    const pageFilters = {
+        listFilter: ListFilterFunction(args.options, args.label, args.description, args.listFilterOptions)
+    };
+
+    return <FilterPage pageFilters={pageFilters} />;
+};
+
 export const ListFilter = ListFilterTemplate.bind({});
+export const ListFilterOneInitialValue = ListFilterTemplateOneValue.bind({});
 
 ListFilter.args = {
     label: 'List Filter',
@@ -50,4 +59,26 @@ ListFilter.args = {
     listFilterOptions: {
         allLabel: 'All Test Data'
     }
+};
+
+ListFilterOneInitialValue.args = {
+    label: 'List Filter One Initial Value',
+    description: 'ListFilter is a checkbox group control meant to be used for multiple filter value combinations.',
+    listFilterOptions: {
+        initialValue: 'good',
+    },
+    options: [
+        {
+            label: 'Good',
+            value: 'good'
+        },
+        {
+            label: 'Better',
+            value: 'better'
+        },
+        {
+            label: 'Best',
+            value: 'best'
+        }
+    ]
 };

--- a/src/stories/Filter/ListFilter/ListFilter.stories.tsx
+++ b/src/stories/Filter/ListFilter/ListFilter.stories.tsx
@@ -46,8 +46,8 @@ const ListFilterTemplate: Story = (args: ListFilterArgs) => {
         listFilter: ListFilterFunction(args.options, args.label, args.description, args.listFilterOptions)
     };
 
-    return <FilterPage pageFilters={pageFilters} />;
-};
+     return <FilterPage pageFilters={pageFilters} />;
+ };
 
 export const ListFilter = ListFilterTemplate.bind({});
 export const ListFilterOneInitialValue = ListFilterTemplateOneValue.bind({});
@@ -65,7 +65,7 @@ ListFilterOneInitialValue.args = {
     label: 'List Filter One Initial Value',
     description: 'ListFilter is a checkbox group control meant to be used for multiple filter value combinations.',
     listFilterOptions: {
-        initialValue: 'good',
+        initialValue: 'better',
     },
     options: [
         {

--- a/src/stories/Filter/ListFilter/ListFilter.stories.tsx
+++ b/src/stories/Filter/ListFilter/ListFilter.stories.tsx
@@ -41,16 +41,8 @@ const ListFilterTemplate: Story = (args: ListFilterArgs) => {
     return <FilterPage pageFilters={pageFilters} />;
 };
 
- const ListFilterTemplateOneValue: Story = (args: ListFilterArgs) => {
-    const pageFilters = {
-        listFilter: ListFilterFunction(args.options, args.label, args.description, args.listFilterOptions)
-    };
-
-     return <FilterPage pageFilters={pageFilters} />;
- };
-
 export const ListFilter = ListFilterTemplate.bind({});
-export const ListFilterOneInitialValue = ListFilterTemplateOneValue.bind({});
+export const ListFilterOneInitialValue = ListFilterTemplate.bind({});
 
 ListFilter.args = {
     label: 'List Filter',


### PR DESCRIPTION
Closing this PR will resolve issue #294 

When all selectable options are selected with an initial value provided, the url will display the entire url params. 
Resetting filters upon initial value provided, will reset all filters applied except the default initial filter. 
Previous functionality is still valid if no initial value is passed by default. 

<img width="1107" alt="Screen Shot 2022-11-16 at 12 46 09 PM" src="https://user-images.githubusercontent.com/87024084/202256515-534c727a-0260-4bbb-91df-d6aff3f7a56e.png">
<img width="1154" alt="Screen Shot 2022-11-16 at 12 45 50 PM" src="https://user-images.githubusercontent.com/87024084/202256517-6d47d68e-1c68-45a2-8d77-0d2466346168.png">


### Lakefront PR Checklist

- [ ]  Created new components following the [contributing guide](#https://github.com/ToyotaResearchInstitute/lakefront/blob/main/CONTRIBUTING.md#adding-new-components).
- [ ]  Exported any new components in the `src/index.ts`.
- [ ]  Updated the main [README table](https://github.com/ToyotaResearchInstitute/lakefront#how-to-add-components-to-this-table).
- [x]  Ensure version numbers were bumped properly.
- [ ]  Imported SVGs with relative path, if applicable.
- [x]  Removed any irrelevant commit messages from merge commit.
- [ ]  Deleted branch after merge.
