### PR TITLE
Add-labels-icon-button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.130.0",
+  "version": "0.130.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.130.0",
+      "version": "0.130.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.128.0",
+  "version": "0.129.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.128.0",
+      "version": "0.129.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.130.1",
+  "version": "0.130.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.130.1",
+      "version": "0.130.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.129.0",
+  "version": "0.130.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.129.0",
+      "version": "0.130.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.129.0",
+  "version": "0.130.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.128.0",
+  "version": "0.129.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.130.0",
+  "version": "0.130.1",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.130.1",
+  "version": "0.130.2",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -10,6 +10,7 @@ import {
     shouldUseMappedIcon
 } from './buttonUtil';
 import theme from 'src/styles/theme';
+import { IconLabelStyles, StyledDiv } from './buttonStyles';
 
 /**
  * Button Component
@@ -46,6 +47,21 @@ const Button: FC<ButtonComponentProps> = ({
             throw new InvalidButtonColorError(color);
         }
 
+        if (iconLabel) {
+            const { className, ...rest } = props;
+            return (
+                <ThemeProvider theme={theme}>
+                    <StyledDiv className={className}>
+                        <ButtonComponent alternate={alternate} {...rest} isIconOnly={isIconOnly}>
+                            <IconButton icon={defaultIcon} iconPosition={iconPosition}>
+                                {children}
+                            </IconButton>
+                        </ButtonComponent>
+                        <IconLabelStyles className='icon-label'>{iconLabel}</IconLabelStyles>
+                    </StyledDiv>
+                </ThemeProvider>
+            );
+        }
         return (
             <ThemeProvider theme={theme}>
                 <ButtonComponent alternate={alternate} {...props} isIconOnly={isIconOnly}>
@@ -53,7 +69,6 @@ const Button: FC<ButtonComponentProps> = ({
                         {children}
                     </IconButton>
                 </ButtonComponent>
-                <div>{iconLabel}</div>
             </ThemeProvider>
         );
     } else {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -29,6 +29,7 @@ const Button: FC<ButtonComponentProps> = ({
     children,
     icon = false,
     iconPosition = 'left',
+    iconLabel = '',
     ...props
 }) => {
     // When an icon is supplied we need to render the IconButton component inside the Button
@@ -52,6 +53,7 @@ const Button: FC<ButtonComponentProps> = ({
                         {children}
                     </IconButton>
                 </ButtonComponent>
+                <div>{iconLabel}</div>
             </ThemeProvider>
         );
     } else {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -10,7 +10,7 @@ import {
     shouldUseMappedIcon
 } from './buttonUtil';
 import theme from 'src/styles/theme';
-import { IconLabelStyles, StyledDiv } from './buttonStyles';
+import { StyledDiv } from './buttonStyles';
 
 /**
  * Button Component
@@ -57,7 +57,7 @@ const Button: FC<ButtonComponentProps> = ({
                                 {children}
                             </IconButton>
                         </ButtonComponent>
-                        <IconLabelStyles className='icon-label'>{iconLabel}</IconLabelStyles>
+                        <div className='icon-label'>{iconLabel}</div>
                     </StyledDiv>
                 </ThemeProvider>
             );

--- a/src/components/Button/__tests__/button.test.jsx
+++ b/src/components/Button/__tests__/button.test.jsx
@@ -151,4 +151,22 @@ describe('Button', () => {
                 .toHaveStyle({ backgroundColor: lightenDarkenColor(THEME.colors.saturatedRed, -10) });
         });
     });
+
+    describe('iconLabel', () => {
+        it('displays the iconLabel below the button when provided and icon is true', () => {
+            const { container } = render(
+                <Button icon={true} iconLabel={'label text'} />
+            );
+
+            expect(container.querySelector('div')).toHaveTextContent('label text');
+        });
+
+        it('doesn\'t display the iconLabel when icon is false / not provided', () => {
+            const { container } = render(
+                <Button iconLabel={'label text'} />
+            );
+
+            expect(container.querySelector('div')).toBe(null);
+        });
+    });
 });

--- a/src/components/Button/buttonStyles.ts
+++ b/src/components/Button/buttonStyles.ts
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+
+export const StyledDiv = styled.div({
+    display: 'inline-block',
+    textAlign: 'center'
+});
+
+export const IconLabelStyles = styled.div({
+    marginTop: 10,
+});

--- a/src/components/Button/buttonStyles.ts
+++ b/src/components/Button/buttonStyles.ts
@@ -4,7 +4,3 @@ export const StyledDiv = styled.div({
     display: 'inline-block',
     textAlign: 'center'
 });
-
-export const IconLabelStyles = styled.div({
-    marginTop: 10,
-});

--- a/src/components/Button/buttonUtil.tsx
+++ b/src/components/Button/buttonUtil.tsx
@@ -67,6 +67,10 @@ export interface IconComponentProps {
      * When icon is defined, the position can be specified via the iconPosition prop.
      */
     iconPosition?: 'left' | 'right';
+    /**
+     * Allows text to render under icon button.
+     */
+    iconLabel?: string;
 }
 
 export type ButtonComponentProps = ButtonProps & IconComponentProps & ComponentPropsWithoutRef<'button'>;

--- a/src/components/RefreshToolbar/__tests__/__snapshots__/RefreshToolbar.test.jsx.snap
+++ b/src/components/RefreshToolbar/__tests__/__snapshots__/RefreshToolbar.test.jsx.snap
@@ -19,7 +19,6 @@ exports[`<RefreshToolbar /> renders button as correctly-styled icon 1`] = `
           </span>
         </span>
       </button>
-      <div />
     </div>
     <div
       class="css-e55m9z"
@@ -56,7 +55,6 @@ exports[`<RefreshToolbar /> renders tooltip on hover 1`] = `
           </span>
         </span>
       </button>
-      <div />
     </div>
     <div
       class="css-e55m9z"

--- a/src/components/RefreshToolbar/__tests__/__snapshots__/RefreshToolbar.test.jsx.snap
+++ b/src/components/RefreshToolbar/__tests__/__snapshots__/RefreshToolbar.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`<RefreshToolbar /> renders button as correctly-styled icon 1`] = `
           </span>
         </span>
       </button>
+      <div />
     </div>
     <div
       class="css-e55m9z"
@@ -55,6 +56,7 @@ exports[`<RefreshToolbar /> renders tooltip on hover 1`] = `
           </span>
         </span>
       </button>
+      <div />
     </div>
     <div
       class="css-e55m9z"

--- a/src/stories/Button/Button.stories.tsx
+++ b/src/stories/Button/Button.stories.tsx
@@ -87,6 +87,7 @@ Destructive.args = {
 export const PrimaryDefaultIcon = Template.bind({});
 PrimaryDefaultIcon.args = {
     ...Primary.args,
+    iconLabel: 'Optional label text',
     icon: true
 };
 
@@ -107,6 +108,7 @@ export const PrimaryIconButton = Template.bind({});
 PrimaryIconButton.args = {
     children: undefined,
     color: 'primary',
+    iconLabel: 'Optional label text',
     icon: true,
     iconPosition: undefined
 };


### PR DESCRIPTION
Added additional prop "iconLabel". This will add a label under the icon button when icon prop is true.
This PR will close issue #271 

<img width="305" alt="Screenshot 2023-01-04 at 4 01 26 PM" src="https://user-images.githubusercontent.com/87024084/210649674-9a701ddc-e1d8-49a0-9da5-0d5d88b47913.png">
<img width="267" alt="Screenshot 2023-01-04 at 4 01 20 PM" src="https://user-images.githubusercontent.com/87024084/210649676-d8238996-7179-450b-90a7-c19802b536a1.png">

### Lakefront PR Checklist

- [ ]  Created new components following the [contributing guide](#https://github.com/ToyotaResearchInstitute/lakefront/blob/main/CONTRIBUTING.md#adding-new-components).
- [ ]  Exported any new components in the `src/index.ts`.
- [ ]  Updated the main [README table](https://github.com/ToyotaResearchInstitute/lakefront#how-to-add-components-to-this-table).
- [ ]  Ensure version numbers were bumped properly.
- [ ]  Imported SVGs with relative path, if applicable.
- [ ]  Removed any irrelevant commit messages from merge commit.
- [ ]  Deleted branch after merge.
