### PR TITLE
Reset all filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "0.136.3",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "0.136.3",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "0.136.3",
+  "version": "1.0.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -16,7 +16,9 @@ import {
     FiltersSection,
     SidePanel,
     PresetFiltersContainer,
-    FilterChipsContainer
+    FilterChipsContainer,
+    FilterPaneControls,
+    FilterControl
 } from './filterStyles';
 import { ReactComponent as FilterIcon } from './assets/filterIcon.svg';
 import theme from 'src/styles/theme';
@@ -170,7 +172,7 @@ export const Filter: FC<FilterComponentProps> = ({
                     <div className='header-chips'>
                         {standardMode && (
                             <FiltersSection className='filters'>
-                                <FilterChipsContainer>
+                                <FilterChipsContainer className='filter-chips-container'>
                                     {panelVisible
                                     .map(([key]) => {
                                         const itemFilterLabelValues = filters[key].getFilterSectionLabel(filterValues[key]);
@@ -187,6 +189,9 @@ export const Filter: FC<FilterComponentProps> = ({
                                         );
                                     })}
                                 </FilterChipsContainer>
+                                <FilterPaneControls>
+                                    <FilterControl color='secondary'>Reset Filters</FilterControl>
+                                </FilterPaneControls>
                             </FiltersSection>
                         )}
                     </div>

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -190,7 +190,12 @@ export const Filter: FC<FilterComponentProps> = ({
                                     })}
                                 </FilterChipsContainer>
                                 <FilterPaneControls>
-                                    <FilterControl color='secondary'>Reset Filters</FilterControl>
+                                    <FilterControl
+                                        color='secondary'
+                                        onClick={resetAllFilters}
+                                    >
+                                        Reset Filters
+                                    </FilterControl>
                                 </FilterPaneControls>
                             </FiltersSection>
                         )}

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -64,7 +64,7 @@ export const Filter: FC<FilterComponentProps> = ({
     // use isCollapsed prop if provided to track state externally, otherwise track state internally
     const isCollapsed = isCollapsedProp === undefined ? isCollapsedState : isCollapsedProp;
 
-    const { filters, filterValues, updateFilter, clearFilter, clearAllFilters, initializePresetValues } = filterHooks;
+    const { filters, filterValues, updateFilter, resetFilter, resetAllFilters, initializePresetValues } = filterHooks;
 
     // save the additional query parameters in the browser url
     useEffect(() => {
@@ -167,7 +167,7 @@ export const Filter: FC<FilterComponentProps> = ({
                                         return (
                                             <FilterValueChips
                                                 label={filters[key].label}
-                                                clearFilter={clearFilter}
+                                                resetFilter={resetFilter}
                                                 key={key}
                                                 name={key}
                                                 notDefaultValues={filters[key] ? !filters[key].isDefaultFilterValue(filterValues[key]) : false}
@@ -195,7 +195,7 @@ export const Filter: FC<FilterComponentProps> = ({
                                                 filter,
                                                 name: key,
                                                 onClick: () => toggleSection(key),
-                                                clearFilter,
+                                                resetFilter,
                                                 value: filterValues[key],
                                                 badgeThreshold
                                             })
@@ -205,7 +205,7 @@ export const Filter: FC<FilterComponentProps> = ({
                                                 filter={filter}
                                                 name={key}
                                                 onClick={() => toggleSection(key)}
-                                                clearFilter={clearFilter}
+                                                resetFilter={resetFilter}
                                                 value={filterValues[key]}
                                                 badgeThreshold={badgeThreshold} />
                                         )}
@@ -247,8 +247,8 @@ export const Filter: FC<FilterComponentProps> = ({
                     <FilterBar
                         filters={filters}
                         filterValues={filterValues}
-                        clearFilter={clearFilter}
-                        clearAllFilter={clearAllFilters}
+                        resetFilter={resetFilter}
+                        resetAllFilters={resetAllFilters}
                     />
                 )}
 

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -14,7 +14,9 @@ import {
     FilterSectionDescription,
     FilterHeader,
     FiltersSection,
-    SidePanel
+    SidePanel,
+    PresetFiltersContainer,
+    FilterChipsContainer
 } from './filterStyles';
 import { ReactComponent as FilterIcon } from './assets/filterIcon.svg';
 import theme from 'src/styles/theme';
@@ -157,11 +159,20 @@ export const Filter: FC<FilterComponentProps> = ({
                             ))}
                         <FilterIcon className="filterMenuIcon" onClick={toggleCollapsed} />
                     </FilterHeader>
+                    {filterMapping && Object.keys(filterMapping).length &&
+                        <PresetFiltersContainer>
+                            <Select aria-label="preset-filter-dropdown"
+                                    options={presetFilterDropdownOptions} onChange={presetFilters}
+                                    value={presetFilterValue}
+                            />
+                        </PresetFiltersContainer>
+                    }
                     <div className='header-chips'>
                         {standardMode && (
                             <FiltersSection className='filters'>
-                                {panelVisible
-                                    .map(([key, filter]) => {
+                                <FilterChipsContainer>
+                                    {panelVisible
+                                    .map(([key]) => {
                                         const itemFilterLabelValues = filters[key].getFilterSectionLabel(filterValues[key]);
 
                                         return (
@@ -175,15 +186,10 @@ export const Filter: FC<FilterComponentProps> = ({
                                                 visible={true} />
                                         );
                                     })}
+                                </FilterChipsContainer>
                             </FiltersSection>
                         )}
                     </div>
-                    {filterMapping && Object.keys(filterMapping).length &&
-                        <Select aria-label="preset-filter-dropdown"
-                                options={presetFilterDropdownOptions} onChange={presetFilters}
-                                value={presetFilterValue}
-                        />
-                    }
                     {standardMode && (
                         <FiltersSection className='filters'>
                             {panelVisible

--- a/src/components/Filter/__tests__/filter.test.jsx
+++ b/src/components/Filter/__tests__/filter.test.jsx
@@ -229,4 +229,16 @@ describe('Filter', () => {
         });
     });
 
+    describe('reset filters functionality', () => {
+        it('displays a "Reset Filters" control in container after filter chips container', () => {
+            const { container } = render(
+                <TestComponent isJSONInputAllowed FilterBar={FilterBar} hideFilterBar={false} />
+            );
+
+            const filterChipsContainer = container.querySelector('.filter-chips-container');
+            const controlsContainer = filterChipsContainer.nextElementSibling;
+
+            within(controlsContainer).getByText('Reset Filters');
+        });
+    });
 });

--- a/src/components/Filter/__tests__/filter.test.jsx
+++ b/src/components/Filter/__tests__/filter.test.jsx
@@ -6,12 +6,18 @@ import { Filter } from '../Filter';
 import { FILTERS, LOCATION } from './filter.data';
 import { useFilter } from '../util';
 
+const mockUseFilter = jest.fn(useFilter);
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
 afterAll(cleanup);
 
 const TestComponent = (props = {}) => {
     const location = { ...LOCATION };
     const updateHistory = jest.fn;
-    const filterHooks = useFilter(FILTERS, false, location, updateHistory);
+    const filterHooks = mockUseFilter(FILTERS, false, location, updateHistory);
 
     return <Filter filterHooks={filterHooks} location={location} updateHistory={updateHistory} {...props} />;
 };
@@ -78,7 +84,7 @@ describe('Filter', () => {
         const TestComponentWithCallback = () => {
             const location = { ...LOCATION };
             const updateHistory = jest.fn;
-            const filterHooks = useFilter(FILTERS, false, location, updateHistory);
+            const filterHooks = mockUseFilter(FILTERS, false, location, updateHistory);
 
             return (
                 <Filter
@@ -239,6 +245,29 @@ describe('Filter', () => {
             const controlsContainer = filterChipsContainer.nextElementSibling;
 
             within(controlsContainer).getByText('Reset Filters');
+        });
+
+        it('calls filter hook resetFilters when button is clicked', () => {
+            const resetAllFilters = jest.fn();
+            mockUseFilter.mockReturnValueOnce({
+                filters: {},
+                filterUrl: '',
+                filterPostBody: {},
+                filterValues: {},
+                updateFilter: () => null,
+                resetFilter: () => null,
+                resetAllFilters,
+                applyApiPostBody: () => null,
+                initializePresetValues: () => null
+            });
+            const { getByText } = render(
+                <TestComponent isJSONInputAllowed FilterBar={FilterBar} hideFilterBar={false} />
+            );
+
+            expect(resetAllFilters).not.toHaveBeenCalled();
+
+            fireEvent.click(getByText('Reset Filters'));
+            expect(resetAllFilters).toHaveBeenCalled();
         });
     });
 });

--- a/src/components/Filter/components/FilterSectionHeader/FilterSectionHeader.tsx
+++ b/src/components/Filter/components/FilterSectionHeader/FilterSectionHeader.tsx
@@ -13,6 +13,7 @@ import { ThemeProvider } from '@emotion/react';
 import theme from 'src/styles/theme';
 import FilterValueChips from './FilterValueChips';
 import { getFilterCount } from './filterSectionHeaderUtil';
+import { FilterChipsContainer } from 'src/components/Filter/filterStyles';
 
 const FilterSectionHeader: FC<FilterSectionHeaderProps> = ({
     activeSection = '',
@@ -51,7 +52,9 @@ const FilterSectionHeader: FC<FilterSectionHeaderProps> = ({
             </FilterSectionHeaderContainer>
             {
                 children ?? (
-                    <FilterValueChips label={filter.label} name={''} visible={showChips} value={filter.getFilterSectionLabel(value)} />
+                    <FilterChipsContainer>
+                        <FilterValueChips label={filter.label} name={''} visible={showChips} value={filter.getFilterSectionLabel(value)} />
+                    </FilterChipsContainer>
                 )
             }
         </ThemeProvider>

--- a/src/components/Filter/components/FilterSectionHeader/FilterSectionHeader.tsx
+++ b/src/components/Filter/components/FilterSectionHeader/FilterSectionHeader.tsx
@@ -16,7 +16,7 @@ import { getFilterCount } from './filterSectionHeaderUtil';
 
 const FilterSectionHeader: FC<FilterSectionHeaderProps> = ({
     activeSection = '',
-    clearFilter,
+    resetFilter,
     filter,
     name,
     onClick,
@@ -26,7 +26,7 @@ const FilterSectionHeader: FC<FilterSectionHeaderProps> = ({
 }) => {
     const handleClear: MouseEventHandler<SVGElement> = (event) => {
         event.stopPropagation();
-        clearFilter(name);
+        resetFilter(name);
     };
 
     const filterApplied = !filter.isDefaultFilterValue(value);

--- a/src/components/Filter/components/FilterSectionHeader/FilterValueChips.tsx
+++ b/src/components/Filter/components/FilterSectionHeader/FilterValueChips.tsx
@@ -9,17 +9,17 @@ interface FilterValueChipsProps {
     label?: FilterModule<any>['label'];
     notDefaultValues?: boolean;
     name: string;
-    clearFilter?(name: string, value?: any): void;
+    resetFilter?(name: string, value?: any): void;
 }
 
-const FilterValueChips: FC<FilterValueChipsProps> = ({ value, visible, name, clearFilter, label, notDefaultValues }) => {
+const FilterValueChips: FC<FilterValueChipsProps> = ({ value, visible, name, resetFilter, label, notDefaultValues }) => {
     if (!visible) {
         return null;
     }
 
     return (
         <FilterValueChipsContainer>
-            {createChips(value, name, clearFilter, label, notDefaultValues)}
+            {createChips(value, name, resetFilter, label, notDefaultValues)}
         </FilterValueChipsContainer>
     );
 };

--- a/src/components/Filter/components/FilterSectionHeader/FilterValueChips.tsx
+++ b/src/components/Filter/components/FilterSectionHeader/FilterValueChips.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react';
 import { createChips } from './filterSectionHeaderUtil';
-import { FilterValueChipsContainer } from './filterSectionHeaderStyles';
 import { FilterModule } from '../../types';
 
 interface FilterValueChipsProps {
@@ -17,11 +16,7 @@ const FilterValueChips: FC<FilterValueChipsProps> = ({ value, visible, name, res
         return null;
     }
 
-    return (
-        <FilterValueChipsContainer>
-            {createChips(value, name, resetFilter, label, notDefaultValues)}
-        </FilterValueChipsContainer>
-    );
+    return createChips(value, name, resetFilter, label, notDefaultValues);
 };
 
 export default FilterValueChips;

--- a/src/components/Filter/components/FilterSectionHeader/__tests__/filterSectionHeader.test.js
+++ b/src/components/Filter/components/FilterSectionHeader/__tests__/filterSectionHeader.test.js
@@ -12,7 +12,7 @@ const FILTER_SECTION_PROPS = {
     },
     name: 'a',
     onClick: jest.fn(),
-    clearFilter: jest.fn(),
+    resetFilter: jest.fn(),
     value: '',
     badgeThreshold: 4
 };
@@ -78,7 +78,7 @@ describe('FilterSectionHeader', () => {
         expect(FILTER_SECTION_PROPS.onClick).toHaveBeenCalled();
     });
 
-    it('Calls clearFilter on clear button click', () => {
+    it('Calls resetFilter on clear button click', () => {
         const { container } = render(
             <FilterSectionHeader
                 {...FILTER_SECTION_PROPS}
@@ -87,6 +87,6 @@ describe('FilterSectionHeader', () => {
         );
 
         fireEvent.click(container.querySelector('svg[aria-label="clear"]'));
-        expect(FILTER_SECTION_PROPS.clearFilter).toHaveBeenCalled();
+        expect(FILTER_SECTION_PROPS.resetFilter).toHaveBeenCalled();
     });
 });

--- a/src/components/Filter/components/FilterSectionHeader/__tests__/filterValueChips.test.js
+++ b/src/components/Filter/components/FilterSectionHeader/__tests__/filterValueChips.test.js
@@ -9,7 +9,7 @@ describe('FilterValueChips', () => {
             <FilterValueChips
                 value={VALUE}
                 name=''
-                clearFilter={() => undefined}
+                resetFilter={() => undefined}
                 visible={false}
             />
         );
@@ -22,7 +22,7 @@ describe('FilterValueChips', () => {
             <FilterValueChips
                 value={VALUE}
                 name=''
-                clearFilter={() => undefined}
+                resetFilter={() => undefined}
                 visible
             />
         );

--- a/src/components/Filter/components/FilterSectionHeader/filterSectionHeaderStyles.ts
+++ b/src/components/Filter/components/FilterSectionHeader/filterSectionHeaderStyles.ts
@@ -7,7 +7,6 @@ export const FilterValueChip = styled.div(({ theme }) => ({
     justifyContent: 'center',
     border: `solid 2px ${theme?.colors?.mercury}`,
     padding: 2,
-    margin: 2,
     borderRadius: 3,
     backgroundColor: theme?.colors?.akoya,
     flexGrow: 1,
@@ -44,14 +43,6 @@ export const FilterLabels = styled.div(({ theme }) => ({
     width: 80,
     fontSize: 10
 }));
-
-export const FilterValueChipsContainer = styled.div({
-    display: 'flex',
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
-    marginTop: 2
-});
 
 export const ClearButton = styled(CloseLabel)(({ theme }) => ({
     marginRight: 8,

--- a/src/components/Filter/filterStyles.ts
+++ b/src/components/Filter/filterStyles.ts
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { FilterContainerProps } from './types';
+import Button from '../Button';
 
 const FILTER_BAR_HEIGHT = 48;
 
@@ -49,7 +50,6 @@ export const SidePanel = styled.div(({ theme }) => ({
     '.header-chips': {
         borderTop: 'unset',
         borderBottom: theme?.borders?.primary,
-        paddingBottom: 15
     },
     section: { padding: '16px 0', borderBottom: theme?.borders?.primary },
     '.options': {
@@ -95,4 +95,17 @@ export const FilterSectionBody = styled.div({
 
 export const PresetFiltersContainer = styled.div({
     marginBottom: 10
+});
+
+export const FilterPaneControls = styled.div({
+    margin: '4px 0',
+    display: 'flex',
+    flexDirection: 'row-reverse',
+});
+
+export const FilterControl = styled(Button)({
+    height: 30,
+    border: 'none',
+    fontSize: 14,
+    display: 'flex'
 });

--- a/src/components/Filter/filterStyles.ts
+++ b/src/components/Filter/filterStyles.ts
@@ -67,6 +67,13 @@ export const FilterHeader = styled.h2({
     }
 });
 
+export const FilterChipsContainer = styled.div({
+    display: 'flex',
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
+    gap: 4,
+});
+
 export const FiltersSection = styled.div({
     position: 'relative',
     '> span': {
@@ -84,4 +91,8 @@ export const FilterSectionDescription = styled.p({
 
 export const FilterSectionBody = styled.div({
     marginTop: 8
+});
+
+export const PresetFiltersContainer = styled.div({
+    marginBottom: 10
 });

--- a/src/components/Filter/modules/DoubleMultiSelectFilter/DoubleMultiSelect.tsx
+++ b/src/components/Filter/modules/DoubleMultiSelectFilter/DoubleMultiSelect.tsx
@@ -76,7 +76,7 @@ const DoubleMultiSelect: FC<DoubleMultiSelectProps> = ({ value, onChange, option
         <div>
             <FilterTitle>
                 <FilterLabel>{options.firstSelect.label}</FilterLabel>
-                <FilterClear onClick={() => handleClear('firstSelect')}>clear all</FilterClear>
+                <FilterClear onClick={() => handleClear('firstSelect')}>reset all</FilterClear>
             </FilterTitle>
             <MultiSelect
                 value={selectedFirst}
@@ -89,7 +89,7 @@ const DoubleMultiSelect: FC<DoubleMultiSelectProps> = ({ value, onChange, option
             />
             <FilterTitle>
                 <FilterLabel>{options.secondSelect.label}</FilterLabel>
-                <FilterClear onClick={() => handleClear('secondSelect')}>clear all</FilterClear>
+                <FilterClear onClick={() => handleClear('secondSelect')}>reset all</FilterClear>
             </FilterTitle>
             <MultiSelect
                 value={selectedSecond}

--- a/src/components/Filter/modules/DoubleMultiSelectFilter/DoubleMultiSelectFilter.tsx
+++ b/src/components/Filter/modules/DoubleMultiSelectFilter/DoubleMultiSelectFilter.tsx
@@ -135,7 +135,7 @@ const DoubleMultiSelectFilter = (
                             <FilterValueChips
                                 visible={firstVisible && firstLength < badgeThreshold}
                                 value={value?.firstSelect}
-                                clearFilter={() => undefined}
+                                resetFilter={() => undefined}
                                 name=''
                             />
                         </FilterSection>
@@ -151,7 +151,7 @@ const DoubleMultiSelectFilter = (
                             <FilterValueChips
                                 visible={secondVisible && secondLength < badgeThreshold}
                                 value={value?.secondSelect}
-                                clearFilter={() => undefined}
+                                resetFilter={() => undefined}
                                 name=''
                             />
                         </FilterSection>

--- a/src/components/Filter/types/index.ts
+++ b/src/components/Filter/types/index.ts
@@ -141,13 +141,13 @@ export interface FilterHooks<T = FilterPostBody> {
      */
     updateFilter(name: string, value: any): void;
     /**
-     * The function to clear a particular filter.
+     * The function to reset a particular filter.
      */
-    clearFilter(name: string | string[], value?: any): void;
+    resetFilter(name: string | string[], value?: any): void;
     /**
-     * The function to clear all current filters.
+     * The function to reset all current filters.
      */
-    clearAllFilters(): void;
+    resetAllFilters(): void;
     /**
      * The function to determine how filters update the post body.
      */
@@ -173,7 +173,7 @@ export interface FilterSectionHeaderProps {
     name: string;
     value: any;
     onClick?: MouseEventHandler<HTMLHeadingElement>;
-    clearFilter: (name: string) => void;
+    resetFilter: (name: string) => void;
     badgeThreshold: number;
 }
 
@@ -242,8 +242,8 @@ export interface ContextSwitchMenuProps {
 export interface FilterBarProps {
     filters: FilterSet;
     filterValues: FilterValues;
-    clearFilter?: (name: string) => void;
-    clearAllFilter?: () => void;
+    resetFilter?: (name: string) => void;
+    resetAllFilters?: () => void;
 }
 
 /**

--- a/src/components/Filter/util/__tests__/filterHooks.test.jsx
+++ b/src/components/Filter/util/__tests__/filterHooks.test.jsx
@@ -79,7 +79,7 @@ describe('useFilter', () => {
         expect(filterPostBody).toEqual({});
     });
 
-    it('clear all filters works', () => {
+    it('reset all filters works', () => {
         const { result } = renderHook(() => useFilter(FILTERS, false, LOCATION, () => null));
 
         act(() => {
@@ -96,7 +96,7 @@ describe('useFilter', () => {
         });
 
         act(() => {
-            result.current.clearAllFilters();
+            result.current.resetAllFilters();
         });
 
         act(() => {
@@ -105,7 +105,7 @@ describe('useFilter', () => {
         });
     });
 
-    it('clear all filter sets default value.', () => {
+    it('reset all filter sets default value.', () => {
         const FILTERS_WITH_DEFAULT_PHRASES = {
             ...FILTERS,
             phrases: {
@@ -131,7 +131,7 @@ describe('useFilter', () => {
         });
 
         act(() => {
-            result.current.clearAllFilters();
+            result.current.resetAllFilters();
         });
 
         act(() => {
@@ -149,7 +149,7 @@ describe('useFilter', () => {
             }
         };
 
-        it('should not change filter value when calling clearFilter', () => {
+        it('should not change filter value when calling resetFilter', () => {
             const { result } = renderHook(() => useFilter(FILTERS_WITH_REQUIRED_PHRASES, false, LOCATION, () => null));
 
             act(() => {
@@ -158,12 +158,12 @@ describe('useFilter', () => {
             expect(result.current.filterValues.phrases).toBe(PHRASE_DEMO);
 
             act(() => {
-                result.current.clearFilter('phrases');
+                result.current.resetFilter('phrases');
             });
             expect(result.current.filterValues.phrases).toBe(PHRASE_DEMO);
         });
 
-        it('should keep existing filter value for required filter only when calling clearAllFilters', () => {
+        it('should keep existing filter value for required filter only when calling resetAllFilters', () => {
             const { result } = renderHook(() => useFilter(FILTERS_WITH_REQUIRED_PHRASES, false, LOCATION, () => null));
 
             act(() => {
@@ -177,7 +177,7 @@ describe('useFilter', () => {
             expect(result.current.filterValues.phrases).toBe(PHRASE_DEMO);
 
             act(() => {
-                result.current.clearAllFilters();
+                result.current.resetAllFilters();
             });
 
             // keywords is cleared/reset, but phrases is not changed
@@ -206,7 +206,7 @@ describe('useFilter', () => {
     });
 
     describe('when a filter has the required property set to false', () => {
-        it('clears filter name when calling clearFilter with no passed value', () => {
+        it('resets filter name when calling resetFilter with no passed value', () => {
             const FILTERS_WITH_NOT_REQUIRED_PHRASES = {
                 ...FILTERS,
                 phrases: {
@@ -222,7 +222,7 @@ describe('useFilter', () => {
             expect(result.current.filterValues.phrases).toBe(PHRASE_DEMO);
 
             act(() => {
-                result.current.clearFilter('phrases');
+                result.current.resetFilter('phrases');
             });
             expect(result.current.filterValues.phrases).toBe('');
         });
@@ -244,7 +244,7 @@ describe('useFilter', () => {
             expect(result.current.filterValues.phrases).toBe(PHRASE_DEMO);
 
             act(() => {
-                result.current.clearFilter('phrases', 'phrases');
+                result.current.resetFilter('phrases', 'phrases');
             });
             expect(result.current.filterValues.phrases).toBe('phrases');
         });
@@ -266,7 +266,7 @@ describe('useFilter', () => {
             expect(result.current.filterValues.phrases).toBe(PHRASE_DEMO);
 
             act(() => {
-                result.current.clearFilter('phrases', 'phrases');
+                result.current.resetFilter('phrases', 'phrases');
             });
             expect(result.current.filterValues.phrases).toBe('');
         });

--- a/src/components/Filter/util/filterHooks.tsx
+++ b/src/components/Filter/util/filterHooks.tsx
@@ -16,7 +16,7 @@ import {
  * The useFilter hook is primarily designed to use with the Filter
  * component, but can be used standalone to maintain filter state.
  * The state as it applies to the current url and a dynamic api post body
- * can be updated and/or cleared using this hook.
+ * can be updated and/or reset using this hook.
  */
 export const useFilter = <T extends FilterPostBody>(
     userFilters: FilterSet,
@@ -56,7 +56,7 @@ export const useFilter = <T extends FilterPostBody>(
     };
 
 
-    const clearFilter = (name: string, value?: any) => {
+    const resetFilter = (name: string, value?: any) => {
         const clearPartial = filters[name].clearPartialSingleFilter;
 
         if (value && clearPartial) {
@@ -84,7 +84,7 @@ export const useFilter = <T extends FilterPostBody>(
         setInitialPresetValues(presetValues);
     };
 
-    const clearAllFilters = () => {
+    const resetAllFilters = () => {
         const newFilterValues: FilterValues = {};
 
         Object.keys(filters).forEach((key) => {
@@ -125,8 +125,8 @@ export const useFilter = <T extends FilterPostBody>(
         filterPostBody,
         filterValues,
         updateFilter,
-        clearFilter,
-        clearAllFilters,
+        resetFilter,
+        resetAllFilters,
         applyApiPostBody,
         initializePresetValues
     };

--- a/src/stories/Filter/components/FilterBar/FilterBar.tsx
+++ b/src/stories/Filter/components/FilterBar/FilterBar.tsx
@@ -4,17 +4,17 @@ import { FilterBarProps, FilterModule } from 'src/components/Filter/types';
 import { FilterBarContainer } from './filterBarStyles';
 
 interface FilterItemProps {
-    clearFilter?(name: string): void;
+    resetFilter?(name: string): void;
     name: string;
     item: FilterModule<any>;
     value: any;
 }
 
 export const FilterItem: FC<FilterItemProps> = (props) => {
-    const { name, clearFilter, item, value } = props;
+    const { name, resetFilter, item, value } = props;
 
     const handleCloseIcon = () => {
-      clearFilter ? clearFilter(name) : undefined;
+        resetFilter ? resetFilter(name) : undefined;
     };
 
     if (item.isDefaultFilterValue(value)) {
@@ -32,7 +32,7 @@ export const FilterItem: FC<FilterItemProps> = (props) => {
 };
 
 const FilterBar: FC<FilterBarProps> = (props) => {
-    const { filters, filterValues, clearFilter, clearAllFilter } = props;
+    const { filters, filterValues, resetFilter, resetAllFilters } = props;
     const [isMinimized, setMinimized] = useState(false);
     const filterBarRef = useRef<HTMLDivElement>(null);
 
@@ -61,15 +61,15 @@ const FilterBar: FC<FilterBarProps> = (props) => {
                             name={key}
                             item={filters[key]}
                             value={filterValues[key]}
-                            clearFilter={clearFilter}
+                            resetFilter={resetFilter}
                         />
                     ))}
                 </>
             )}
 
             {filterCount > 0 && (
-                <span onClick={clearAllFilter} className="clearAll">
-                    Clear All
+                <span onClick={resetAllFilters} className="resetAll">
+                    Reset All
                 </span>
             )}
         </FilterBarContainer>

--- a/src/stories/Filter/components/FilterBar/filterBarStyles.ts
+++ b/src/stories/Filter/components/FilterBar/filterBarStyles.ts
@@ -30,7 +30,7 @@ export const FilterBarContainer = styled.div(({ theme }) => ({
             cursor: 'pointer'
         }
     },
-    '.clearAll': {
+    '.resetAll': {
         color: theme.colors.saturatedBlue,
         cursor: 'pointer'
     }


### PR DESCRIPTION
### Version 1.0.x BREAKING CHANGES
This PR is for updating the "clear filter(s)" functionality of filters to now be "reset filter(s)". In order to fully accomplish this, the interface for the `userFilter` hook result has changed. Consuming libraries will generally need to do a find and replace for any instances of "clear" if using those parts of the useFilter result.

<img width="935" alt="image" src="https://user-images.githubusercontent.com/80778550/216157309-17749a0e-d31f-4ba0-ab75-070dc376a767.png">

### Lakefront PR Checklist

- [ ]  Created new components following the [contributing guide](#https://github.com/ToyotaResearchInstitute/lakefront/blob/main/CONTRIBUTING.md#adding-new-components).
- [ ]  Exported any new components in the `src/index.ts`.
- [ ]  Updated the main [README table](https://github.com/ToyotaResearchInstitute/lakefront#how-to-add-components-to-this-table).
- [ ]  Ensure version numbers were bumped properly.
- [ ]  Imported SVGs with relative path, if applicable.
- [ ]  Removed any irrelevant commit messages from merge commit.
- [ ]  Deleted branch after merge.
