### PR TITLE
Add link prop for breadcrumbs

### DIFF
--- a/.github/workflows/versionBumpCheck.yml
+++ b/.github/workflows/versionBumpCheck.yml
@@ -22,7 +22,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          bump-policy: 'last-commit'
           skip-tag:  'true'
           minor-wording:  'minor,Minor,MINOR,add,Adds,ADD,ADDS,new,New,NEW,feat,Feat,FEAT,feature,Feature,FEATURE,features,Features,FEATURES'
           major-wording:  'major,MAJOR,cut-major,Cut-Major,break,Break,BREAK,breaking,Breaking,BREAKING'

--- a/.github/workflows/versionBumpCheck.yml
+++ b/.github/workflows/versionBumpCheck.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          bump-policy: 'last-commit'
           skip-tag:  'true'
           minor-wording:  'minor,Minor,MINOR,add,Adds,ADD,ADDS,new,New,NEW,feat,Feat,FEAT,feature,Feature,FEATURE,features,Features,FEATURES'
           major-wording:  'major,MAJOR,cut-major,Cut-Major,break,Break,BREAK,breaking,Breaking,BREAKING'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "2.2.0",
+  "version": "2.1.8-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "2.2.0",
+      "version": "2.1.8-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "2.3.0",
+  "version": "2.3.1-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "2.3.0",
+      "version": "2.3.1-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "2.1.8-rc.2",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "2.1.8-rc.2",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "2.3.1-rc.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "2.3.1-rc.0",
+      "version": "2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "2.2.0",
+  "version": "2.1.8-rc.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "2.2.0",
+      "version": "2.1.8-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "2.1.8-rc.3",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "2.1.8-rc.3",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "2.2.0",
+  "version": "2.1.8-rc.3",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "2.1.8-rc.3",
+  "version": "2.2.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "2.1.8-rc.2",
+  "version": "2.2.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "2.3.0",
+  "version": "2.3.1-rc.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "2.3.1-rc.0",
+  "version": "2.3.1",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "2.2.0",
+  "version": "2.1.8-rc.2",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import { FC, RefAttributes } from 'react';
+import { LinkProps, Link as ReactRouterDomLink } from 'react-router-dom';
 
 import { BreadCrumbStyle, Current, Divider } from './breadcrumbStyles';
 import { ThemeProvider } from '@emotion/react';
@@ -22,13 +22,18 @@ export interface BreadcrumbProps {
      *  You can also set the url for the breadcrumb to navigate to the appropriate link.
      */
     routes: RouteProp[];
+    /**
+     * This allows you to pass your own Link connected to your application router.
+     * This is most useful for applications using React-router v6 and above.
+     */
+    Link?: FC<LinkProps & RefAttributes<HTMLAnchorElement>>;
 }
 
 /**
  *  The Breadcrumb Component is used to render the breadcrumb. The Name of the Breadcrumb is displayed.
  *  The url can be used to link to the appropriate link.
  */
-const Breadcrumb: React.FC<BreadcrumbProps> = ({ routes }) => {
+const Breadcrumb: FC<BreadcrumbProps> = ({ routes, Link = ReactRouterDomLink }) => {
 
     return (
         <ThemeProvider theme={theme}>

--- a/src/components/Breadcrumb/BreadcrumbHeader.tsx
+++ b/src/components/Breadcrumb/BreadcrumbHeader.tsx
@@ -1,7 +1,8 @@
-import React, { ReactNode } from 'react';
+import { FC, ReactNode, RefAttributes } from 'react';
 
 import Breadcrumb, { RouteProp } from './Breadcrumb';
 import { Container, Content } from './breadcrumbStyles';
+import { LinkProps } from 'react-router-dom';
 
 export interface BreadcrumbHeaderProps {
     /**
@@ -25,7 +26,12 @@ export interface BreadcrumbHeaderProps {
     /**
      * Children to display as the content.
      */
-    children?: ReactNode
+    children?: ReactNode;
+    /**
+     * This allows you to pass your own Link connected to your application router.
+     * This is most useful for applications using React-router v6 and above.
+     */
+    Link?: FC<LinkProps & RefAttributes<HTMLAnchorElement>>;
 }
 
 /**
@@ -35,11 +41,11 @@ export interface BreadcrumbHeaderProps {
  * prop or a wrapper). Set [standalone] to true to add full-width behavior with margins and
  * a bottom border (to function as a standalone header). Defaults to true.
  */
-const BreadcrumbHeader: React.FC<BreadcrumbHeaderProps> = ({ routes, className,
-    standalone = true, hideRoutes = false, children }) => {
+const BreadcrumbHeader: FC<BreadcrumbHeaderProps> = ({ routes, className,
+    standalone = true, hideRoutes = false, children, Link }) => {
     return (
         <Container className={className} standalone={standalone}>
-            <Breadcrumb routes={hideRoutes ? [] : routes} />
+            <Breadcrumb routes={hideRoutes ? [] : routes} Link={Link} />
             {children && <Content>{children}</Content>}
         </Container>
     );

--- a/src/components/Breadcrumb/BreadcrumbHeader.tsx
+++ b/src/components/Breadcrumb/BreadcrumbHeader.tsx
@@ -1,5 +1,4 @@
 import { FC, ReactNode, RefAttributes } from 'react';
-
 import Breadcrumb, { RouteProp } from './Breadcrumb';
 import { Container, Content } from './breadcrumbStyles';
 import { LinkProps } from 'react-router-dom';


### PR DESCRIPTION
Added Link prop to Breadcrumbs to connect to application router.

### Lakefront PR Checklist

- [ ]  Created new components following the [contributing guide](#https://github.com/ToyotaResearchInstitute/lakefront/blob/main/CONTRIBUTING.md#adding-new-components).
- [ ]  Exported any new components in the `src/index.ts`.
- [ ]  Updated the main [README table](https://github.com/ToyotaResearchInstitute/lakefront#how-to-add-components-to-this-table).
- [ ]  Ensure version numbers were bumped properly.
- [ ]  Imported SVGs with relative path, if applicable.
- [ ]  Removed any irrelevant commit messages from merge commit.
- [ ]  Deleted branch after merge.
