### PR TITLE
LAKEHOUSE 549 disable icon label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toyota-research-institute/lakefront",
-  "version": "5.3.3",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@toyota-research-institute/lakefront",
-      "version": "5.3.3",
+      "version": "5.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toyota-research-institute/lakefront",
   "description": "React UI Components",
-  "version": "5.3.3",
+  "version": "5.4.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/ToyotaResearchInstitute/lakefront",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,11 +3,11 @@ import { ThemeProvider } from '@emotion/react';
 import ButtonVariants from './buttonVariants';
 import IconButton from './IconButton';
 import {
-    ButtonComponentProps,
-    ICON_BUTTON_COLOR,
-    ICON_SVGS,
-    InvalidButtonColorError,
-    shouldUseMappedIcon
+  ButtonComponentProps,
+  ICON_BUTTON_COLOR,
+  ICON_SVGS,
+  InvalidButtonColorError,
+  shouldUseMappedIcon
 } from './buttonUtil';
 import theme from 'src/styles/theme';
 import { StyledDiv } from './buttonStyles';
@@ -25,64 +25,76 @@ import { StyledDiv } from './buttonStyles';
  * we will attempt to convert it into an icon. When icon is defined, the position can be specified via the iconPosition prop.
  */
 const Button: FC<ButtonComponentProps> = ({
-    alternate = false,
-    color = 'primary',
-    children,
-    icon = false,
-    iconPosition = 'left',
-    iconLabel = '',
-    ...props
+  alternate = false,
+  color = 'primary',
+  children,
+  icon = false,
+  iconPosition = 'left',
+  iconLabel = '',
+  ...props
 }) => {
-    // When an icon is supplied we need to render the IconButton component inside the Button
-    if (icon) {
-        // If icon is true, we need to show the icon associated with the button color type, such as add or delete
-        const defaultIcon = shouldUseMappedIcon(icon) ? ICON_SVGS[color ?? 'primary'] : icon;
-        const isIconOnly = !children || !defaultIcon;
+  // When an icon is supplied we need to render the IconButton component inside the Button
+  if (icon) {
+    // If icon is true, we need to show the icon associated with the button color type, such as add or delete
+    const defaultIcon = shouldUseMappedIcon(icon)
+      ? ICON_SVGS[color ?? 'primary']
+      : icon;
+    const isIconOnly = !children || !defaultIcon;
 
-        // Icon Buttons have a different color mapping, i.e. there is no secondary, but primary uses the secondary component
-        const ButtonComponent = isIconOnly ? ButtonVariants[ICON_BUTTON_COLOR[color]] : ButtonVariants[color];
+    // Icon Buttons have a different color mapping, i.e. there is no secondary, but primary uses the secondary component
+    const ButtonComponent = isIconOnly
+      ? ButtonVariants[ICON_BUTTON_COLOR[color]]
+      : ButtonVariants[color];
 
-        // Show a meaningful error when the color doesn't match our allowed color strings instead of crashing the page
-        if (!ButtonComponent) {
-            throw new InvalidButtonColorError(color);
-        }
-
-        if (iconLabel) {
-            const { className, ...rest } = props;
-            return (
-                <ThemeProvider theme={theme}>
-                    <StyledDiv className={className}>
-                        <ButtonComponent alternate={alternate} {...rest} isIconOnly={isIconOnly}>
-                            <IconButton icon={defaultIcon} iconPosition={iconPosition}>
-                                {children}
-                            </IconButton>
-                        </ButtonComponent>
-                        <div className='icon-label'>{iconLabel}</div>
-                    </StyledDiv>
-                </ThemeProvider>
-            );
-        }
-        return (
-            <ThemeProvider theme={theme}>
-                <ButtonComponent alternate={alternate} {...props} isIconOnly={isIconOnly}>
-                    <IconButton icon={defaultIcon} iconPosition={iconPosition}>
-                        {children}
-                    </IconButton>
-                </ButtonComponent>
-            </ThemeProvider>
-        );
-    } else {
-        // Like in the Icon version, we return a styled component based on the color type
-        const ButtonComponent = ButtonVariants[color] || ButtonVariants.primary;
-
-        return (
-            <ThemeProvider theme={theme}>
-                <ButtonComponent alternate={alternate} {...props}>
-                    {children}
-                </ButtonComponent>
-            </ThemeProvider>
-        );
+    // Show a meaningful error when the color doesn't match our allowed color strings instead of crashing the page
+    if (!ButtonComponent) {
+      throw new InvalidButtonColorError(color);
     }
+
+    if (iconLabel) {
+      const { className, ...rest } = props;
+      return (
+        <ThemeProvider theme={theme}>
+          <StyledDiv className={className} disable={props.disabled ?? false}>
+            <ButtonComponent
+              alternate={alternate}
+              {...rest}
+              isIconOnly={isIconOnly}
+            >
+              <IconButton icon={defaultIcon} iconPosition={iconPosition}>
+                {children}
+              </IconButton>
+            </ButtonComponent>
+            <div className="icon-label">{iconLabel}</div>
+          </StyledDiv>
+        </ThemeProvider>
+      );
+    }
+    return (
+      <ThemeProvider theme={theme}>
+        <ButtonComponent
+          alternate={alternate}
+          {...props}
+          isIconOnly={isIconOnly}
+        >
+          <IconButton icon={defaultIcon} iconPosition={iconPosition}>
+            {children}
+          </IconButton>
+        </ButtonComponent>
+      </ThemeProvider>
+    );
+  } else {
+    // Like in the Icon version, we return a styled component based on the color type
+    const ButtonComponent = ButtonVariants[color] || ButtonVariants.primary;
+
+    return (
+      <ThemeProvider theme={theme}>
+        <ButtonComponent alternate={alternate} {...props}>
+          {children}
+        </ButtonComponent>
+      </ThemeProvider>
+    );
+  }
 };
 
 export default Button;

--- a/src/components/Button/__tests__/button.test.jsx
+++ b/src/components/Button/__tests__/button.test.jsx
@@ -6,167 +6,218 @@ import { lightenDarkenColor } from 'src/styles/stylesUtil';
 const BUTTON_TEXT = 'buttonText';
 
 const THEME = {
-    colors: {
-        white: 'white',
-        storm: 'gray',
-        saturatedRed: 'red'
-    }
+  colors: {
+    white: 'white',
+    storm: 'gray',
+    saturatedRed: 'red'
+  }
 };
 
 const onClick = jest.fn();
 
 describe('Button', () => {
-    describe('general rendering', () => {
-        it('renders child text', () => {
-            const { getByText } = render(<Button>{BUTTON_TEXT}</Button>);
+  describe('general rendering', () => {
+    it('renders child text', () => {
+      const { getByText } = render(<Button>{BUTTON_TEXT}</Button>);
 
-            getByText(BUTTON_TEXT);
-        });
-
-        it('renders additional child types', () => {
-            const [divID, pID] = ['divID', 'pID'];
-            const { container } = render(
-                <Button>
-                    <div id={divID}>
-                        <p id={pID}>{BUTTON_TEXT}</p>
-                    </div>
-                </Button>
-            );
-
-            expect(container.querySelector(`#${divID}`)).toBeInTheDocument();
-            expect(container.querySelector(`#${pID}`)).toBeInTheDocument();
-        });
+      getByText(BUTTON_TEXT);
     });
 
-    describe('when enabled', () => {
-        it('triggers button handler when clicked', () => {
-            const { getByText } = render(<Button onClick={onClick}>{BUTTON_TEXT}</Button>);
+    it('renders additional child types', () => {
+      const [divID, pID] = ['divID', 'pID'];
+      const { container } = render(
+        <Button>
+          <div id={divID}>
+            <p id={pID}>{BUTTON_TEXT}</p>
+          </div>
+        </Button>
+      );
 
-            fireEvent.click(getByText(BUTTON_TEXT));
+      expect(container.querySelector(`#${divID}`)).toBeInTheDocument();
+      expect(container.querySelector(`#${pID}`)).toBeInTheDocument();
+    });
+  });
 
-            expect(onClick).toHaveBeenCalled();
-        });
+  describe('when enabled', () => {
+    it('triggers button handler when clicked', () => {
+      const { getByText } = render(
+        <Button onClick={onClick}>{BUTTON_TEXT}</Button>
+      );
 
-        it('renders primary variant when color is undefined', () => {
-            const { getByRole } = render(<Button theme={THEME}>{BUTTON_TEXT}</Button>);
+      fireEvent.click(getByText(BUTTON_TEXT));
 
-            expect(getByRole('button')).toHaveStyle({ backgroundColor: THEME.colors.storm });
-        });
-
-        it('renders primary variant when color does not exist', () => {
-            const { getByRole } = render(<Button color="non_existing_color" theme={THEME}>{BUTTON_TEXT}</Button>);
-
-            expect(getByRole('button')).toHaveStyle({ backgroundColor: THEME.colors.storm });
-        });
-
-        it('renders primary variant when specified', () => {
-            const { getByRole } = render(<Button color="primary" theme={THEME}>{BUTTON_TEXT}</Button>);
-
-            expect(getByRole('button')).toHaveStyle({ backgroundColor: THEME.colors.storm });
-        });
-
-        it('renders secondary variant when specified', () => {
-            const { getByRole } = render(<Button color="secondary" theme={THEME}>{BUTTON_TEXT}</Button>);
-
-            expect(getByRole('button')).toHaveStyle({ backgroundColor: 'transparent' });
-        });
-
-        it('renders desctructive variant when specified', () => {
-            const { getByRole } = render(<Button color="destructive" theme={THEME}>{BUTTON_TEXT}</Button>);
-
-            expect(getByRole('button')).toHaveStyle({ backgroundColor: 'transparent' });
-        });
+      expect(onClick).toHaveBeenCalled();
     });
 
-    describe('when alternate prop is provided', () => {
-        it('renders the alternate primary style.', () => {
-            const { getByRole } = render(
-                <Button alternate color="primary" theme={THEME}>
-                    {BUTTON_TEXT}
-                </Button>
-            );
+    it('renders primary variant when color is undefined', () => {
+      const { getByRole } = render(
+        <Button theme={THEME}>{BUTTON_TEXT}</Button>
+      );
 
-            expect(getByRole('button')).toHaveStyle({ color: THEME.colors.storm });
-        });
-
-        it('renders the alternate secondary style.', () => {
-            const { getByRole } = render(
-                <Button alternate color="secondary" theme={THEME}>
-                    {BUTTON_TEXT}
-                </Button>
-            );
-
-            expect(getByRole('button')).toHaveStyle({ color: THEME.colors.white });
-        });
-
-        it('renders the alternate destructive style.', () => {
-            const { getByRole } = render(
-                <Button alternate color="destructive" theme={THEME}>
-                    {BUTTON_TEXT}
-                </Button>
-            );
-
-            expect(getByRole('button')).toHaveStyle({ color: THEME.colors.white });
-        });
+      expect(getByRole('button')).toHaveStyle({
+        backgroundColor: THEME.colors.storm
+      });
     });
 
-    describe('when disabled', () => {
-        it('renders with disabled styles', () => {
-            const { getByText } = render(<Button disabled>{BUTTON_TEXT}</Button>);
+    it('renders primary variant when color does not exist', () => {
+      const { getByRole } = render(
+        <Button color="non_existing_color" theme={THEME}>
+          {BUTTON_TEXT}
+        </Button>
+      );
 
-            expect(getByText(BUTTON_TEXT)).toHaveStyle({ cursor: 'not-allowed' });
-        });
-
-        it('prevents button handler when clicked', () => {
-            const { getByText } = render(<Button disabled>{BUTTON_TEXT}</Button>);
-
-            fireEvent.click(getByText(BUTTON_TEXT));
-
-            expect(onClick).not.toHaveBeenCalled();
-        });
+      expect(getByRole('button')).toHaveStyle({
+        backgroundColor: THEME.colors.storm
+      });
     });
 
-    describe('when hovered', () => {
-        it('renders the primary variant properly', () => {
-            const { getByText } = render(<Button color="primary">{BUTTON_TEXT}</Button>);
+    it('renders primary variant when specified', () => {
+      const { getByRole } = render(
+        <Button color="primary" theme={THEME}>
+          {BUTTON_TEXT}
+        </Button>
+      );
 
-            fireEvent.mouseOver(getByText(BUTTON_TEXT));
-            expect(getByText(BUTTON_TEXT))
-                .toHaveStyle({ backgroundColor: lightenDarkenColor(THEME.colors.storm, -10) });
-        });
-
-        it('renders the secondary variant properly', () => {
-            const { getByText } = render(<Button color="secondary">{BUTTON_TEXT}</Button>);
-
-            fireEvent.mouseOver(getByText(BUTTON_TEXT));
-            expect(getByText(BUTTON_TEXT))
-                .toHaveStyle({ backgroundColor: lightenDarkenColor(THEME.colors.white, -10) });
-        });
-
-        it('renders the destructive variant properly', () => {
-            const { getByText } = render(<Button color="destructive">{BUTTON_TEXT}</Button>);
-
-            fireEvent.mouseOver(getByText(BUTTON_TEXT));
-            expect(getByText(BUTTON_TEXT))
-                .toHaveStyle({ backgroundColor: lightenDarkenColor(THEME.colors.saturatedRed, -10) });
-        });
+      expect(getByRole('button')).toHaveStyle({
+        backgroundColor: THEME.colors.storm
+      });
     });
 
-    describe('iconLabel', () => {
-        it('displays the iconLabel below the button when provided and icon is true', () => {
-            const { container } = render(
-                <Button icon={true} iconLabel={'label text'} />
-            );
+    it('renders secondary variant when specified', () => {
+      const { getByRole } = render(
+        <Button color="secondary" theme={THEME}>
+          {BUTTON_TEXT}
+        </Button>
+      );
 
-            expect(container.querySelector('div')).toHaveTextContent('label text');
-        });
-
-        it('doesn\'t display the iconLabel when icon is false / not provided', () => {
-            const { container } = render(
-                <Button iconLabel={'label text'} />
-            );
-
-            expect(container.querySelector('div')).toBe(null);
-        });
+      expect(getByRole('button')).toHaveStyle({
+        backgroundColor: 'transparent'
+      });
     });
+
+    it('renders desctructive variant when specified', () => {
+      const { getByRole } = render(
+        <Button color="destructive" theme={THEME}>
+          {BUTTON_TEXT}
+        </Button>
+      );
+
+      expect(getByRole('button')).toHaveStyle({
+        backgroundColor: 'transparent'
+      });
+    });
+  });
+
+  describe('when alternate prop is provided', () => {
+    it('renders the alternate primary style.', () => {
+      const { getByRole } = render(
+        <Button alternate color="primary" theme={THEME}>
+          {BUTTON_TEXT}
+        </Button>
+      );
+
+      expect(getByRole('button')).toHaveStyle({ color: THEME.colors.storm });
+    });
+
+    it('renders the alternate secondary style.', () => {
+      const { getByRole } = render(
+        <Button alternate color="secondary" theme={THEME}>
+          {BUTTON_TEXT}
+        </Button>
+      );
+
+      expect(getByRole('button')).toHaveStyle({ color: THEME.colors.white });
+    });
+
+    it('renders the alternate destructive style.', () => {
+      const { getByRole } = render(
+        <Button alternate color="destructive" theme={THEME}>
+          {BUTTON_TEXT}
+        </Button>
+      );
+
+      expect(getByRole('button')).toHaveStyle({ color: THEME.colors.white });
+    });
+  });
+
+  describe('when disabled', () => {
+    it('renders with disabled styles', () => {
+      const { getByText } = render(<Button disabled>{BUTTON_TEXT}</Button>);
+
+      expect(getByText(BUTTON_TEXT)).toHaveStyle({ cursor: 'not-allowed' });
+    });
+
+    it('prevents button handler when clicked', () => {
+      const { getByText } = render(<Button disabled>{BUTTON_TEXT}</Button>);
+
+      fireEvent.click(getByText(BUTTON_TEXT));
+
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when hovered', () => {
+    it('renders the primary variant properly', () => {
+      const { getByText } = render(
+        <Button color="primary">{BUTTON_TEXT}</Button>
+      );
+
+      fireEvent.mouseOver(getByText(BUTTON_TEXT));
+      expect(getByText(BUTTON_TEXT)).toHaveStyle({
+        backgroundColor: lightenDarkenColor(THEME.colors.storm, -10)
+      });
+    });
+
+    it('renders the secondary variant properly', () => {
+      const { getByText } = render(
+        <Button color="secondary">{BUTTON_TEXT}</Button>
+      );
+
+      fireEvent.mouseOver(getByText(BUTTON_TEXT));
+      expect(getByText(BUTTON_TEXT)).toHaveStyle({
+        backgroundColor: lightenDarkenColor(THEME.colors.white, -10)
+      });
+    });
+
+    it('renders the destructive variant properly', () => {
+      const { getByText } = render(
+        <Button color="destructive">{BUTTON_TEXT}</Button>
+      );
+
+      fireEvent.mouseOver(getByText(BUTTON_TEXT));
+      expect(getByText(BUTTON_TEXT)).toHaveStyle({
+        backgroundColor: lightenDarkenColor(THEME.colors.saturatedRed, -10)
+      });
+    });
+  });
+
+  describe('iconLabel', () => {
+    it('displays the iconLabel at normal opacity below the enabled button when provided and icon is true', () => {
+      const { container } = render(
+        <Button icon={true} iconLabel={'label text'} />
+      );
+
+      expect(container.querySelector('div')).toHaveTextContent('label text');
+      expect(container.querySelector('.icon-label')).toHaveStyle({
+        opacity: '1'
+      });
+    });
+
+    it("doesn't display the iconLabel when icon is false / not provided", () => {
+      const { container } = render(<Button iconLabel={'label text'} />);
+
+      expect(container.querySelector('div')).toBe(null);
+    });
+
+    it('displays lower opacity icon label when disabled', () => {
+      const { container } = render(
+        <Button icon={true} iconLabel={'label text'} disabled />
+      );
+
+      expect(container.querySelector('div')).toHaveTextContent('label text');
+      expect(container.querySelector('.icon-label')).toHaveStyle({
+        opacity: '0.4'
+      });
+    });
+  });
 });

--- a/src/components/Button/buttonStyles.ts
+++ b/src/components/Button/buttonStyles.ts
@@ -1,6 +1,11 @@
 import styled from '@emotion/styled';
 
-export const StyledDiv = styled.div({
-    display: 'inline-block',
-    textAlign: 'center'
-});
+interface StyledDivProps {
+  disable: boolean;
+}
+
+export const StyledDiv = styled('div')<StyledDivProps>(({ disable }) => ({
+  display: 'inline-block',
+  textAlign: 'center',
+  '& > div.icon-label': { opacity: disable ? 0.4 : 1 }
+}));


### PR DESCRIPTION
-changed styling on icon label to reflect 'disabled' attribute
<img width="246" alt="image" src="https://github.com/ToyotaResearchInstitute/lakefront/assets/120043905/44467baf-7aa3-4e34-b595-1722bddb0548">
<img width="188" alt="image" src="https://github.com/ToyotaResearchInstitute/lakefront/assets/120043905/abe6393e-0278-49e3-a841-d9c15bcb45b3">



### Lakefront PR Checklist

- [ ]  Created new components following the [contributing guide](#https://github.com/ToyotaResearchInstitute/lakefront/blob/main/CONTRIBUTING.md#adding-new-components).
- [ ]  Exported any new components in the `src/index.ts`.
- [ ]  Updated the main [README table](https://github.com/ToyotaResearchInstitute/lakefront#how-to-add-components-to-this-table).
- [ ]  Ensure version numbers were bumped properly.
- [ ]  Imported SVGs with relative path, if applicable.
- [ ]  Removed any irrelevant commit messages from merge commit.
- [ ]  Deleted branch after merge.
